### PR TITLE
fixed bug in inversion of 1D covariance matrices

### DIFF
--- a/main/ejml-ddense/src/org/ejml/dense/row/CovarianceOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CovarianceOps_DDRM.java
@@ -95,7 +95,7 @@ public class CovarianceOps_DDRM {
             if( cov.numCols >= 2 )
                 UnrolledInverseFromMinor_DDRM.inv(cov,cov_inv);
             else
-                cov_inv.data[0] = 1.0/cov_inv.data[0];
+                cov_inv.data[0] = 1.0/cov.data[0];
 
         } else {
             LinearSolverDense<DMatrixRMaj> solver = LinearSolverFactory_DDRM.symmPosDef(cov.numRows);


### PR DESCRIPTION
Hi,
There is a minor bug when inverting a 1D covariance matrix due to a typo, this patch should fix it.

Best,
Ciamac.