### PR TITLE
Add abs() operation for DMatrixRMaj in CommonsOps_DDRM

### DIFF
--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -2862,4 +2862,41 @@ public class CommonOps_DDRM {
         }
         return output;
     }
+
+    /**
+     * <p>Performs absolute value of a matrix:<br>
+     * <br>
+     * c = abs(a)<br>
+     * c<sub>ij</sub> = abs(a<sub>ij</sub>)
+     * </p>
+     *
+     * @param a A matrix. Not modified.
+     * @param c A matrix. Modified.
+     */
+    public static void abs(DMatrixD1 a , DMatrixD1 c ) {
+        c.reshape(a.numRows,a.numCols);
+
+        final int length = a.getNumElements();
+
+        for ( int i = 0; i < length; i++ ) {
+            c.data[i] = Math.abs(a.data[i]);
+        }
+    }
+
+    /**
+     * <p>Performs absolute value of a matrix:<br>
+     * <br>
+     * a = abs(a)<br>
+     * a<sub>ij</sub> = abs(a<sub>ij</sub>)
+     * </p>
+     *
+     * @param a A matrix. Modified.
+     */
+    public static void abs(DMatrixD1 a ) {
+        final int length = a.getNumElements();
+
+        for ( int i = 0; i < length; i++ ) {
+            a.data[i] = Math.abs(a.data[i]);
+        }
+    }
 }

--- a/main/ejml-ddense/test/org/ejml/dense/row/TestCommonOps_DDRM.java
+++ b/main/ejml-ddense/test/org/ejml/dense/row/TestCommonOps_DDRM.java
@@ -1726,4 +1726,20 @@ public class TestCommonOps_DDRM {
             }
         }
     }
+
+
+    @Test
+    public void absoluteValue() {
+        DMatrixRMaj A = RandomMatrices_DDRM.rectangle(5,4,rand);
+        DMatrixRMaj C = new DMatrixRMaj(5,4);
+
+        CommonOps_DDRM.abs(A, C);
+
+        for (int i = 0; i < C.numRows; i++) {
+            for (int j = 0; j < C.numCols; j++) {
+                assertEquals(C.get(i,j), Math.abs(C.get(i, j)),0);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Add two variants for the absolute value of a matrix. The result is the absolute value for each element.