### PR TITLE
Enable tests running via gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ subprojects {
     test {
         ignoreFailures true
         reports.html.enabled = false
+        useJUnitPlatform {
+            includeEngines 'junit-jupiter'
+        }
     }
 
     repositories {


### PR DESCRIPTION
This change makes it possible to run the test via "./gradlew test".
Working in Intelij, tests are executed by default via gradle.
Previously no tests could be found for this project.

In addition, this change allows running the test in CI.

Currently `org.ejml.data.TestDMatrixSparseCSC#growMaxLength_veryLarge` throws an OutOfMemory Exception.
As a `double` needs 8 bytes and the matrix in the test has the dimensions `10^9 x 10^9`, it might be better to just disable the test.