### PR TITLE
Add apply and reduce methods

### DIFF
--- a/main/autocode/src/org/ejml/GenerateJavaCode32.java
+++ b/main/autocode/src/org/ejml/GenerateJavaCode32.java
@@ -50,6 +50,10 @@ public class GenerateJavaCode32 extends GenerateCode32 {
 
         prefix64.add("DGrow");
         prefix32.add("FGrow");
+        prefix64.add("DUnary");
+        prefix32.add("FUnary");
+        prefix64.add("DBinary");
+        prefix32.add("FBinary");
         prefix64.add("DScalar");
         prefix32.add("FScalar");
         prefix64.add("DMatrix");
@@ -87,6 +91,8 @@ public class GenerateJavaCode32 extends GenerateCode32 {
         }
 
         converter.replacePattern("DScalar", "FScalar");
+        converter.replacePattern("DUnary", "FUnary");
+        converter.replacePattern("DBinary", "FBinary");
         converter.replacePattern("ConvertD", "ConvertF");
         converter.replacePattern("DGrowArray", "FGrowArray");
         converter.replacePattern("DMatrix", "FMatrix");

--- a/main/ejml-core/src/org/ejml/ops/DBinaryOperator.java
+++ b/main/ejml-core/src/org/ejml/ops/DBinaryOperator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.ops;
+
+/**
+ * Functional Interface used in reduce methods to specify arbitrary binary functions accepting doubles
+ */
+@FunctionalInterface
+public interface DBinaryOperator {
+    double apply(double x, double y);
+}

--- a/main/ejml-core/src/org/ejml/ops/DUnaryOperator.java
+++ b/main/ejml-core/src/org/ejml/ops/DUnaryOperator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.ops;
+
+/**
+ * Functional Interface used in apply method to specify arbitrary unary functions accepting a double
+ */
+@FunctionalInterface
+public interface DUnaryOperator {
+    double apply(double d);
+}

--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -36,6 +36,7 @@ import org.ejml.dense.row.mult.MatrixVectorMult_DDRM;
 import org.ejml.dense.row.mult.VectorVectorMult_DDRM;
 import org.ejml.interfaces.linsol.LinearSolverDense;
 import org.ejml.interfaces.linsol.ReducedRowEchelonForm_F64;
+import org.ejml.ops.DUnaryOperator;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -3002,5 +3003,33 @@ public class CommonOps_DDRM {
                 A.data[row*cols+col] = A.data[col*cols+row];
             }
         }
+    }
+
+    /**
+     * This applies a given unary function on every value stored in the matrix
+     *
+     * B = f(A).   A and B can be the same instance.
+     *
+     * @param input  (Input) input matrix. Not modified
+     * @param func   Unary function accepting a double
+     * @param output (Output) Matrix. Modified.
+     * @return The output matrix
+     */
+    public static DMatrixRMaj apply(DMatrixRMaj input, DUnaryOperator func, @Nullable DMatrixRMaj output) {
+        if (output == null) {
+            output = input.createLike();
+        } else if (input != output) {
+            output.reshape(input.numRows, input.numCols);
+        }
+
+        for (int i = 0; i < input.data.length; i++) {
+            output.data[i] = func.apply(input.data[i]);
+        }
+
+        return output;
+    }
+
+    public static DMatrixRMaj apply(DMatrixRMaj input, DUnaryOperator func) {
+        return apply(input, func, input);
     }
 }

--- a/main/ejml-ddense/test/org/ejml/dense/row/TestCommonOps_DDRM.java
+++ b/main/ejml-ddense/test/org/ejml/dense/row/TestCommonOps_DDRM.java
@@ -29,8 +29,10 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Random;
 
+import static org.ejml.UtilEjml.checkSameShape;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1820,5 +1822,20 @@ public class TestCommonOps_DDRM {
                 assertEquals(O.get(j,i),A.get(i,j), UtilEjml.TEST_F64);
             }
         }
+    }
+
+    @Test
+    public void applyFunc() {
+        DMatrixRMaj A = RandomMatrices_DDRM.rectangle(10, 10, rand);
+        DMatrixRMaj B = A.copy();
+        CommonOps_DDRM.apply(A, (double x) -> 2 * x + 1, B);
+
+        double[] expectedResult = new double[A.getNumElements()];
+        for (int i = 0; i < A.getNumElements(); i++) {
+            expectedResult[i] = A.data[i] * 2 + 1;
+        }
+
+        checkSameShape(A, B, false);
+        assertTrue(Arrays.equals(expectedResult, B.data));
     }
 }

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
@@ -26,11 +26,13 @@ import org.ejml.data.IGrowArray;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.interfaces.decomposition.LUSparseDecomposition_F64;
 import org.ejml.interfaces.linsol.LinearSolverSparse;
+import org.ejml.ops.DBinaryOperator;
 import org.ejml.sparse.FillReducing;
 import org.ejml.sparse.csc.factory.DecompositionFactory_DSCC;
 import org.ejml.sparse.csc.factory.LinearSolverFactory_DSCC;
 import org.ejml.sparse.csc.misc.ImplCommonOps_DSCC;
 import org.ejml.sparse.csc.mult.ImplSparseSparseMult_DSCC;
+import org.ejml.ops.DUnaryOperator;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -1830,6 +1832,124 @@ public class CommonOps_DSCC {
                     output += A.nz_values[i];
                     break;
                 }
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * This applies a given unary function on every value stored in the matrix
+     *
+     * B = f(A).   A and B can be the same instance.
+     *
+     * @param input  (Input) input matrix. Not modified
+     * @param func   Unary function accepting a double
+     * @param output (Output) Matrix. Modified.
+     * @return The output matrix
+     */
+    public static DMatrixSparseCSC apply(DMatrixSparseCSC input, DUnaryOperator func, @Nullable DMatrixSparseCSC output) {
+        if (output == null) {
+            output = input.createLike();
+        } else if (input != output) {
+            output.copyStructure(input);
+        }
+
+        for (int i = 0; i < input.nz_length; i++) {
+            output.nz_values[i] = func.apply(input.nz_values[i]);
+        }
+
+        return output;
+    }
+
+    public static DMatrixSparseCSC apply(DMatrixSparseCSC input, DUnaryOperator func) {
+        return apply(input, func, input);
+    }
+
+    /**
+     * This accumulates the matrix values to a scalar value
+     *
+     * a = ⊕A. Where ⊕ is specified via the `func` parameter
+     *
+     * @param input (Input) input matrix. Not modified
+     * @param initValue initial value for accumulator
+     * @param func Accumulator function defining "+" for accumulator +=  cellValue
+     * @return accumulated value
+     */
+    public static double reduceScalar(DMatrixSparseCSC input, double initValue, DBinaryOperator func) {
+        double result = initValue;
+
+        for (int i = 0; i < input.nz_length; i++) {
+            result = func.apply(result, input.nz_values[i]);
+        }
+
+        return result;
+    }
+
+    public static double reduceScalar(DMatrixSparseCSC input, DBinaryOperator func) {
+        return reduceScalar(input, 0, func);
+    }
+
+    /**
+     * This accumulates the values per column to a scalar value
+     *
+     *  a[i] = ⊕A[;i]. Where ⊕ is specified via the `func` parameter
+     *
+     * @param input     (Input) input matrix. Not modified
+     * @param initValue initial value for accumulator
+     * @param func      Accumulator function defining "+" for accumulator +=  cellValue
+     * @param output    output (Output) Vector, where result can be stored in
+     * @return a column-vector, where v[i] == values of column i reduced to scalar based on `func`
+     */
+    public static DMatrixRMaj reduceColumnWise(DMatrixSparseCSC input, double initValue, DBinaryOperator func, @Nullable DMatrixRMaj output) {
+        if (output == null) {
+            output = new DMatrixRMaj(1, input.numCols);
+        } else {
+            output.reshape(1, input.numCols);
+        }
+
+        for (int col = 0; col < input.numCols; col++) {
+            int start = input.col_idx[col];
+            int end = input.col_idx[col + 1];
+
+            double acc = initValue;
+            for (int i = start; i < end; i++) {
+                acc = func.apply(acc, input.nz_values[i]);
+            }
+
+            // TODO: allow optional resultAccumulator function (use tmp_result array to save reduce result and than combine arrays f.i. 2nd func)
+            output.data[col] = acc;
+        }
+
+        return output;
+    }
+
+    /**
+     * This accumulates the values per row to a scalar value
+     *
+     * a[i] = ⊕A[i;]. Where ⊕ is specified via the `func` parameter
+     *
+     * @param input     (Input) input matrix. Not modified
+     * @param initValue initial value for accumulator
+     * @param func      Accumulator function defining "+" for accumulator +=  cellValue
+     * @param output    output (Output) Vector, where result can be stored in
+     * @return a row-vector, where v[i] == values of row i reduced to scalar based on `func`
+     */
+    public static DMatrixRMaj reduceRowWise(DMatrixSparseCSC input, double initValue, DBinaryOperator func, @Nullable DMatrixRMaj output) {
+        if (output == null) {
+            output = new DMatrixRMaj(1, input.numRows);
+        } else {
+            output.reshape(1, input.numCols);
+        }
+        // TODO: allow optional resultAccumulator function (use tmp_result array to save reduce result and than combine arrays f.i. 2nd func)
+        Arrays.fill(output.data, initValue);
+
+        for (int col = 0; col < input.numCols; col++) {
+            int start = input.col_idx[col];
+            int end = input.col_idx[col + 1];
+
+            for (int i = start; i < end; i++) {
+                output.data[input.nz_rows[i]] = func.apply(output.data[input.nz_rows[i]], input.nz_values[i]);
             }
         }
 

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/TestCommonOps_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/TestCommonOps_DSCC.java
@@ -30,6 +30,7 @@ import org.ejml.ops.ConvertDMatrixStruct;
 import org.ejml.sparse.csc.mult.ImplSparseSparseMult_DSCC;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -1455,5 +1456,68 @@ public class TestCommonOps_DSCC {
 
         double found = CommonOps_DSCC.trace(A);
         assertEquals(expected,found,UtilEjml.TEST_F64);
+    }
+
+    @Test
+    public void applyFunc() {
+        DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(10, 10, 20, rand);
+        DMatrixSparseCSC B = A.copy();
+        CommonOps_DSCC.apply(A, x -> 2 * x + 1, B);
+
+        double[] expectedResult = new double[A.nz_length];
+        for (int i = 0; i < A.nz_length; i++) {
+            expectedResult[i] = A.nz_values[i] * 2 + 1;
+        }
+
+        assertTrue(Arrays.equals(A.col_idx, B.col_idx));
+        assertTrue(Arrays.equals(A.nz_rows, B.nz_rows));
+        assertTrue(Arrays.equals(expectedResult, B.nz_values));
+    }
+
+    @Test
+    public void reduceScalar() {
+        DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(10, 10, 20, rand);
+        double result = CommonOps_DSCC.reduceScalar(A, 0, (acc, x) -> acc + x);
+
+        double expectedResult = 0;
+        for (int i = 0; i < A.getNumElements(); i++) {
+            expectedResult += A.nz_values[i];
+        }
+
+        assertTrue(expectedResult == result);
+    }
+
+    @Test
+    public void reduceColumnWise() {
+        DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(10, 10, 20, rand);
+
+        DMatrixRMaj result = CommonOps_DSCC.reduceColumnWise(A, 0, (acc, x) -> acc + x, null);
+
+        for (int i = 0; i < A.numCols; i++) {
+            DMatrixSparseCSC colVector = CommonOps_DSCC.extractColumn(A, i, null);
+            double expected = 0;
+            for (int j = 0; j < colVector.nz_length; j++) {
+                expected += colVector.nz_values[j];
+            }
+            assertEquals(expected, result.get(i));
+        }
+    }
+
+    @Test
+    public void reduceRowWise() {
+        DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(10, 10, 20, rand);
+
+        DMatrixRMaj result = CommonOps_DSCC.reduceRowWise(A, 0, (acc, x) -> acc + x, null);
+
+        for (int i = 0; i < A.numCols; i++) {
+            DMatrixSparseCSC A_trans = CommonOps_DSCC.transpose(A, null, null);
+            // as A_t[i,:]  == A[:,i]
+            DMatrixSparseCSC rowVector = CommonOps_DSCC.extractColumn(A_trans, i, null);
+            double expected = 0;
+            for (int j = 0; j < rowVector.nz_length; j++) {
+                expected += rowVector.nz_values[j];
+            }
+            assertEquals(expected, result.get(i));
+        }
     }
 }


### PR DESCRIPTION
Allows the execution of "arbitrary" functions over matrices.

Apply: Given a input matrix, a unary function and an output matrix, the function is applied on every element in the matrix and saved in the corresponding cell in the output matrix.

Reduce:
- based on a input matrx, an intial value, a binary function
- 3 variants:
  - reduceScalar: returning a single double/float
  - reduceColumnWise: accumulating the values per column to a double/float
  - reduceRowWise: accumulating the values per row to a double/float  

Apply is implemented for sparse and dense matrices.
Reduce is currently only implemented for sparse matrices (should be very straightforward to add dense matrices).

The functions seem to be inlined and therefore produce only little to no overhead, compared to the existing hard-coded apply/reduce methods like `scale` or `columnMaxAbs`. (benchmarks + results can be found at https://github.com/FlorentinD/ejml/tree/benchmarks/benchmark)