### PR TITLE
Allow a fallbackValue for `get()` on sparse matrices

### DIFF
--- a/main/ejml-core/src/org/ejml/data/DMatrixSparse.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparse.java
@@ -28,6 +28,30 @@ import java.util.Iterator;
 public interface DMatrixSparse extends DMatrix, MatrixSparse {
 
     /**
+     * Returns the value of value of the specified matrix element.
+     *
+     * @param row           Matrix element's row index..
+     * @param col           Matrix element's column index.
+     * @param fallBackValue Value to return, if the matrix element is not assigned
+     * @return The specified element's value.
+     */
+    double get(int row, int col, double fallBackValue);
+
+
+    /**
+     * Same as {@link #get} but does not perform bounds check on input parameters.  This results in about a 25%
+     * speed increase but potentially sacrifices stability and makes it more difficult to track down simple errors.
+     * It is not recommended that this function be used, except in highly optimized code where the bounds are
+     * implicitly being checked.
+     *
+     * @param row           Matrix element's row index..
+     * @param col           Matrix element's column index.
+     * @param fallBackValue Value to return, if the matrix element is not assigned
+     * @return The specified element's value or the fallBackValue, if the element is not assigned.
+     */
+    double unsafe_get(int row, int col, double fallBackValue);
+
+    /**
      * Creates an iterator which will go through each non-zero value in the sparse matrix. Order is not defined
      * and is implementation specific
      *

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -179,11 +179,27 @@ public class DMatrixSparseCSC implements DMatrixSparse {
     }
 
     @Override
+    public double get(int row, int col, double fallBackValue) {
+        if( row < 0 || row >= numRows || col < 0 || col >= numCols )
+            throw new IllegalArgumentException("Outside of matrix bounds");
+
+        return unsafe_get(row,col, fallBackValue);
+    }
+
+    @Override
     public double unsafe_get(int row, int col) {
         int index = nz_index(row,col);
         if( index >= 0 )
             return nz_values[index];
         return 0;
+    }
+
+    @Override
+    public double unsafe_get(int row, int col, double fallBackValue) {
+        int index = nz_index(row,col);
+        if( index >= 0 )
+            return nz_values[index];
+        return fallBackValue;
     }
 
     /**

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -199,11 +199,37 @@ public class DMatrixSparseTriplet implements DMatrixSparse
         return unsafe_get(row,col);
     }
 
+    /**
+     * Searches the list to see if the element at (row,col) has been assigned. The worst case runtime for this
+     * operation is O(N), where N is the number of elements in the matrix.
+     *
+     * @param row           Matrix element's row index.
+     * @param col           Matrix element's column index.
+     * @param fallBackValue Value to return, if the element is not assigned
+     * @return Value at (row,col) or the fallBackValue, if the element is not assigned.
+     */
+    @Override
+    public double get(int row, int col, double fallBackValue) {
+        if (row < 0 || row >= numRows || col < 0 || col >= numCols)
+            throw new IllegalArgumentException("Outside of matrix bounds");
+
+        return unsafe_get(row, col, fallBackValue);
+    }
+
     @Override
     public double unsafe_get(int row, int col) {
         int index = nz_index(row,col);
         if( index < 0 )
             return 0;
+        else
+            return nz_value.data[index];
+    }
+
+    @Override
+    public double unsafe_get(int row, int col, double fallBackValue) {
+        int index = nz_index(row,col);
+        if( index < 0 )
+            return fallBackValue;
         else
             return nz_value.data[index];
     }

--- a/main/ejml-core/test/org/ejml/data/GenericTestsDMatrixSparse.java
+++ b/main/ejml-core/test/org/ejml/data/GenericTestsDMatrixSparse.java
@@ -122,6 +122,28 @@ public abstract class GenericTestsDMatrixSparse extends GenericTestsDMatrix
     }
 
     @Test
+    public void get_with_fallBackValue() {
+        DMatrixSparseTriplet tmp = new DMatrixSparseTriplet(3,4,1);
+        tmp.addItem(1,2,5);
+
+        DMatrixSparse m = createSparse(tmp);
+
+        m.set(1,2, 5);
+
+        double fallBackValue = 42;
+
+        for (int row = 0; row < m.getNumRows(); row++) {
+            for (int col = 0; col < m.getNumCols(); col++) {
+                double found = m.get(row,col, fallBackValue);
+                if( row == 1 && col == 2)
+                    assertEquals(5, found, UtilEjml.TEST_F64);
+                else
+                    assertEquals(fallBackValue, found, UtilEjml.TEST_F64);
+            }
+        }
+    }
+
+    @Test
     public void remove_case0() {
         DMatrixSparse m = (DMatrixSparse)createMatrix(3,4);
         DMatrixSparse c = m.copy();


### PR DESCRIPTION
Sometimes, an unassigned entry does not mean `0` but f.i. `Double.MAX_VALUE` for `min()`.

I duplicated the existing `get(x,y)` and `unsafe_get()` methods.
An alternative would be, for the existing ones to call `get(x,y, 0)`, but I thougth to avoid additional function calls.
Better be cautious how good the compiler can inline the calls, right?