### PR TITLE
Fix reshapeOrDeclare bug for sparse matrices

### DIFF
--- a/main/ejml-core/src/org/ejml/UtilEjml.java
+++ b/main/ejml-core/src/org/ejml/UtilEjml.java
@@ -112,6 +112,36 @@ public class UtilEjml {
 
     /**
      * If the input matrix is null a new matrix is created and returned. If it exists it will be reshaped and returned.
+     * @param a (Input/Output) matrix which is to be checked. Can be null.
+     * @param rows Desired number of rows
+     * @param cols Desired number of cols
+     * @return modified matrix or new matrix
+     */
+    public static DMatrixSparseCSC reshapeOrDeclare(@Nullable DMatrixSparseCSC a , int rows, int cols ) {
+        if( a == null )
+            return new DMatrixSparseCSC(rows,cols);
+        else if( a.numRows != rows || a.numCols != cols )
+            a.reshape(rows,cols);
+        return a;
+    }
+
+    /**
+     * If the input matrix is null a new matrix is created and returned. If it exists it will be reshaped and returned.
+     * @param a (Input/Output) matrix which is to be checked. Can be null.
+     * @param rows Desired number of rows
+     * @param cols Desired number of cols
+     * @return modified matrix or new matrix
+     */
+    public static FMatrixSparseCSC reshapeOrDeclare(@Nullable FMatrixSparseCSC a , int rows, int cols ) {
+        if( a == null )
+            return new FMatrixSparseCSC(rows,cols);
+        else if( a.numRows != rows || a.numCols != cols )
+            a.reshape(rows,cols);
+        return a;
+    }
+
+    /**
+     * If the input matrix is null a new matrix is created and returned. If it exists it will be reshaped and returned.
      * @param target (Input/Output) matrix which is to be checked. Can be null.
      * @param reference (Input) Refernece matrix who's shape will be matched
      * @return modified matrix or new matrix

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
@@ -147,7 +147,7 @@ public class CommonOps_DSCC {
     {
         if( A.numCols != B.numRows )
             throw new MatrixDimensionException("Inconsistent matrix shapes. "+stringShapes(A,B));
-        output = reshapeOrDeclare(output,A,A.numRows,B.numCols);
+        output = reshapeOrDeclare(output, A.numRows,B.numCols);
 
         ImplSparseSparseMult_DSCC.mult(A,B,output, gw, gx);
 
@@ -159,7 +159,7 @@ public class CommonOps_DSCC {
     {
         if( A.numRows != B.numRows )
             throw new MatrixDimensionException("Inconsistent matrix shapes. "+stringShapes(A,B));
-        output = reshapeOrDeclare(output,A,A.numCols,B.numCols);
+        output = reshapeOrDeclare(output, A.numCols,B.numCols);
 
         ImplSparseSparseMult_DSCC.multTransA(A,B,output,gw,gx);
 
@@ -182,7 +182,7 @@ public class CommonOps_DSCC {
     {
         if( A.numCols != B.numCols )
             throw new MatrixDimensionException("Inconsistent matrix shapes. "+stringShapes(A,B));
-        output = reshapeOrDeclare(output,A,A.numRows,B.numRows);
+        output = reshapeOrDeclare(output, A.numRows, B.numRows);
 
         if( !B.isIndicesSorted() )
             B.sortIndices(null);

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/TestCommonOps_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/TestCommonOps_DSCC.java
@@ -20,6 +20,7 @@ package org.ejml.sparse.csc;
 
 import org.ejml.EjmlUnitTests;
 import org.ejml.UtilEjml;
+import org.ejml.data.DMatrix;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.DMatrixSparseTriplet;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.ejml.EjmlUnitTests.assertShape;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -178,6 +180,19 @@ public class TestCommonOps_DSCC {
                 }
             }
         }
+    }
+
+    @Test
+    public void test_null_version() {
+        DMatrixSparseCSC A = new DMatrixSparseCSC(2, 4);
+        DMatrixSparseCSC B = new DMatrixSparseCSC(4, 2);
+
+        DMatrixSparseCSC prevCreated = new DMatrixSparseCSC(10, 10);
+
+        DMatrixSparseCSC result = CommonOps_DSCC.mult(A, B, null);
+        DMatrixSparseCSC otherResult = CommonOps_DSCC.mult(A, B, prevCreated);
+
+        assertShape(result, otherResult);
     }
 
     @Test


### PR DESCRIPTION
.. previously used version resulted in row and col values being ignored if the output matrix was not declared yet.
This resulted in wrongly shaped result matrices.

The test could be removed, as it is only to illustrate the bug. 
