### PR TITLE
Replace findbugs annotation with jetbrains

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ subprojects {
     }
 
     dependencies {
-        compile 'com.google.code.findbugs:jsr305:3.0.2' // @Nullable
+        compile 'org.jetbrains:annotations:20.0.0' // @Nullable
 
         testImplementation( 'org.junit.jupiter:junit-jupiter-api:5.4.0' )
         testRuntimeOnly( 'org.junit.jupiter:junit-jupiter-engine:5.4.0' )

--- a/main/ejml-core/src/org/ejml/UtilEjml.java
+++ b/main/ejml-core/src/org/ejml/UtilEjml.java
@@ -25,7 +25,7 @@ import org.ejml.interfaces.linsol.LinearSolverSparse;
 import org.ejml.ops.ConvertDMatrixStruct;
 import org.ejml.ops.ConvertFMatrixStruct;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.text.DecimalFormat;

--- a/main/ejml-core/src/org/ejml/ops/ConvertDArrays.java
+++ b/main/ejml-core/src/org/ejml/ops/ConvertDArrays.java
@@ -22,7 +22,7 @@ import org.ejml.UtilEjml;
 import org.ejml.data.DMatrix4;
 import org.ejml.data.DMatrixRMaj;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Converts 1D and 2D arrays to and from EJML data types

--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -38,7 +38,7 @@ import org.ejml.interfaces.linsol.LinearSolverDense;
 import org.ejml.interfaces.linsol.ReducedRowEchelonForm_F64;
 import org.ejml.ops.DUnaryOperator;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 import static org.ejml.UtilEjml.*;

--- a/main/ejml-ddense/src/org/ejml/dense/row/SingularOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/SingularOps_DDRM.java
@@ -28,7 +28,7 @@ import org.ejml.dense.row.linsol.svd.SolveNullSpaceSvd_DDRM;
 import org.ejml.interfaces.SolveNullSpace;
 import org.ejml.interfaces.decomposition.SingularValueDecomposition_F64;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
@@ -34,7 +34,7 @@ import org.ejml.sparse.csc.factory.LinearSolverFactory_DSCC;
 import org.ejml.sparse.csc.misc.ImplCommonOps_DSCC;
 import org.ejml.sparse.csc.mult.ImplSparseSparseMult_DSCC;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 import static org.ejml.UtilEjml.*;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOps_DSCC.java
@@ -23,7 +23,7 @@ import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.IGrowArray;
 import org.ejml.sparse.csc.CommonOps_DSCC;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 import static org.ejml.UtilEjml.adjust;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/TriangularSolver_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/TriangularSolver_DSCC.java
@@ -24,7 +24,7 @@ import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.IGrowArray;
 import org.ejml.interfaces.linsol.LinearSolverDense;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Peter Abeles

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplSparseSparseMult_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplSparseSparseMult_DSCC.java
@@ -24,7 +24,7 @@ import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.IGrowArray;
 import org.ejml.sparse.csc.CommonOps_DSCC;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 import static org.ejml.UtilEjml.adjust;


### PR DESCRIPTION
# Introduction

Per #77, the current state of `findbugs` is less than ideal. As such, this PR replaces it with `java-annotations` [from Jetbrains](https://github.com/JetBrains/java-annotations).

# Changes

First, I replaced `'com.google.code.findbugs:jsr305:3.0.2'` with `'org.jetbrains:annotations:20.0.0'` in `build.gradle`. Then, I changed all imports of `javax.annotation.Nullable` via

```
grep -rl 'import .*Nullable;' . | xargs sed -i '' "s/import javax.annotation.Nullable;/import org.jetbrains.annotations.Nullable;/g"
```

# Testing

Everything still compiles, tests, and checks via gradle just fine:

```
~/github/ejml ∃ ./gradlew autogenerate
~/github/ejml ∃ ./gradlew build
~/github/ejml ∃ ./gradlew test
~/github/ejml ∃ ./gradlew check
```

Thanks very much!