### PR TITLE
Use binary search if indices are sorted for `nz_index` in CSC matrix

### DIFF
--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -216,12 +216,16 @@ public class DMatrixSparseCSC implements DMatrixSparse {
         int col0 = col_idx[col];
         int col1 = col_idx[col + 1];
 
-        for (int i = col0; i < col1; i++) {
-            if (nz_rows[i] == row) {
-                return i;
+        if (this.indicesSorted) {
+            return Arrays.binarySearch(nz_rows, col0, col1, row);
+        } else {
+            for (int i = col0; i < col1; i++) {
+                if (nz_rows[i] == row) {
+                    return i;
+                }
             }
+            return -1;
         }
-        return -1;
     }
 
     @Override


### PR DESCRIPTION
This is very useful, for larger columns as this function now takes `O(ld n)` instead of `O(N)`, when the entries are sorted.