### PR TITLE
Fix bug in random matrix generator and add a Benchmark

### DIFF
--- a/main/ejml-dsparse/benchmarks/src/org/ejml/sparse/csc/BenchmarkRandomMatrices_DSCC.java
+++ b/main/ejml-dsparse/benchmarks/src/org/ejml/sparse/csc/BenchmarkRandomMatrices_DSCC.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.sparse.csc;
+
+import org.ejml.data.DGrowArray;
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.data.DMatrixSparseCSC;
+import org.ejml.data.IGrowArray;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Peter Abeles
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@Fork(value = 2)
+public class BenchmarkRandomMatrices_DSCC {
+
+    @Param({"10000","40000"})
+    private int dimension;
+
+    @Param({"10", "300"})
+    private int avgEntriesPerColumn;
+
+    Random rand = new Random(345);
+
+    @Benchmark public void rectangle() { RandomMatrices_DSCC.rectangle(dimension, dimension, avgEntriesPerColumn * dimension, -1, 1, rand); }
+    @Benchmark public void generateUniform() { RandomMatrices_DSCC.generateUniform(dimension, dimension, avgEntriesPerColumn, -1, 1, rand); }
+
+    public static void main( String[] args ) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(BenchmarkRandomMatrices_DSCC.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/TestRandomMatrices_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/TestRandomMatrices_DSCC.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Peter Abeles
  */
+@SuppressWarnings("UnusedMethod")
 public class TestRandomMatrices_DSCC {
     Random rand = new Random(324);
 

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/mult/TestMatrixVectorMultWithSemiRing_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/mult/TestMatrixVectorMultWithSemiRing_DSCC.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("UnusedMethod")
 public class TestMatrixVectorMultWithSemiRing_DSCC {
     DMatrixSparseCSC inputMatrix;
 


### PR DESCRIPTION
Resulting in the wrong row selection strategy being used, and hence being very very slow.

Corresponding issue: #98 

Other changes are:
- when selecting rows, they are directly written
- use boolean[] instead of BitSet
- use for-each instead for Streaming BitSet

Thanks @ennerf for the last two tips!