### PR TITLE
Implement `select` operation for csc matrices

### DIFF
--- a/main/ejml-core/src/org/ejml/ops/IPredicateBinary.java
+++ b/main/ejml-core/src/org/ejml/ops/IPredicateBinary.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.ops;
+
+/**
+ * Functional Interface used in matrix select methods to specify arbitrary binary predicates accepting element coordinates
+ */
+@FunctionalInterface
+public interface IPredicateBinary {
+    // TODO: add a version, where the value is also relevant f.i. for selecting non-zero entries
+    boolean apply( int row, int col );
+}

--- a/main/ejml-core/src/org/ejml/ops/IPredicatesBinary.java
+++ b/main/ejml-core/src/org/ejml/ops/IPredicatesBinary.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.ops;
+
+/**
+ * Inspired by the predefined SelectOps in GraphBLAS (spec extension)
+ */
+public class IPredicatesBinary {
+    public static final IPredicateBinary lowerTriangle = ( row, col ) -> row >= col;
+    public static final IPredicateBinary higherTriangle = ( row, col ) -> row <= col;
+    public static final IPredicateBinary diagonal = ( row, col ) -> row == col;
+    public static final IPredicateBinary nonDiagonal = ( row, col ) -> row != col;
+}

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc;
 
 import org.ejml.MatrixDimensionException;
@@ -29,6 +28,7 @@ import org.ejml.interfaces.linsol.LinearSolverSparse;
 import org.ejml.ops.DOperatorBinary;
 import org.ejml.ops.DOperatorBinaryIdx;
 import org.ejml.ops.DOperatorUnary;
+import org.ejml.ops.IPredicateBinary;
 import org.ejml.sparse.FillReducing;
 import org.ejml.sparse.csc.factory.DecompositionFactory_DSCC;
 import org.ejml.sparse.csc.factory.LinearSolverFactory_DSCC;
@@ -1222,6 +1222,29 @@ public class CommonOps_DSCC {
                 }
             }
         }
+    }
+
+    /**
+     * Select entries from A and save them in C.
+     * A more generic but probably also slower version of `extract`
+     * <p>
+     * Can be used to select f.i. the lower or upper triangle of a matrix
+     * <p>
+     * Simplified version of: GxB_Select
+     *
+     * @param A           (Input) Matrix. Not modified.
+     * @param selector    Function to decide whether an entry gets selected
+     * @param output      (Optional/Output) Matrix to use for the output. Can be the same as A
+     * @return Matrix storing the selected entries of A
+     */
+    public static DMatrixSparseCSC select( DMatrixSparseCSC A, IPredicateBinary selector, @Nullable DMatrixSparseCSC output) {
+        if (output != A) {
+            output = reshapeOrDeclare(output, A);
+        }
+
+        ImplCommonOps_DSCC.select(A, output, selector);
+
+        return output;
     }
 
     /**

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/misc/TestImplCommonOps_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/misc/TestImplCommonOps_DSCC.java
@@ -24,6 +24,8 @@ import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.DMatrixSparseTriplet;
 import org.ejml.data.IGrowArray;
 import org.ejml.ops.DConvertMatrixStruct;
+import org.ejml.ops.IPredicateBinary;
+import org.ejml.ops.IPredicatesBinary;
 import org.ejml.sparse.csc.CommonOps_DSCC;
 import org.ejml.sparse.csc.MatrixFeatures_DSCC;
 import org.ejml.sparse.csc.RandomMatrices_DSCC;
@@ -32,8 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Peter Abeles
@@ -47,20 +48,20 @@ public class TestImplCommonOps_DSCC {
         for (int rows = 1; rows <= 10; rows++) {
             for (int cols = 1; rows <= 10; rows++) {
                 for (int mc = 0; mc < 20; mc++) {
-                    int N =(int) Math.round(rows*cols*rand.nextDouble());
-                    DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(rows,cols,N, -1, 1, rand);
-                    DMatrixSparseCSC b = new DMatrixSparseCSC(0,0,0);
+                    int N = (int)Math.round(rows*cols*rand.nextDouble());
+                    DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(rows, cols, N, -1, 1, rand);
+                    DMatrixSparseCSC b = new DMatrixSparseCSC(0, 0, 0);
 
-                    ImplCommonOps_DSCC.transpose(a,b,null);
-                    assertEquals(cols,b.numRows);
-                    assertEquals(rows,b.numCols);
+                    ImplCommonOps_DSCC.transpose(a, b, null);
+                    assertEquals(cols, b.numRows);
+                    assertEquals(rows, b.numCols);
 
                     for (int row = 0; row < rows; row++) {
                         for (int col = 0; col < cols; col++) {
-                            double expected = a.get(row,col);
-                            double found = b.get(col,row);
+                            double expected = a.get(row, col);
+                            double found = b.get(col, row);
 
-                            assertEquals(expected, found, UtilEjml.TEST_F64,row+" "+col);
+                            assertEquals(expected, found, UtilEjml.TEST_F64, row + " " + col);
                         }
                     }
                     assertTrue(CommonOps_DSCC.checkSortedFlag(b));
@@ -74,23 +75,23 @@ public class TestImplCommonOps_DSCC {
         double alpha = 1.5;
         double beta = 2.3;
 
-        for( int numRows : new int[]{2,4,6,10}) {
-            for( int numCols : new int[]{2,4,6,10}) {
-                DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(numRows,numCols,7, -1, 1, rand);
-                DMatrixSparseCSC b = RandomMatrices_DSCC.rectangle(numRows,numCols,8, -1, 1, rand);
-                DMatrixSparseCSC c = RandomMatrices_DSCC.rectangle(numRows,numCols,3, -1, 1, rand);
+        for (int numRows : new int[]{2, 4, 6, 10}) {
+            for (int numCols : new int[]{2, 4, 6, 10}) {
+                DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(numRows, numCols, 7, -1, 1, rand);
+                DMatrixSparseCSC b = RandomMatrices_DSCC.rectangle(numRows, numCols, 8, -1, 1, rand);
+                DMatrixSparseCSC c = RandomMatrices_DSCC.rectangle(numRows, numCols, 3, -1, 1, rand);
 
-                ImplCommonOps_DSCC.add(alpha,a,beta,b,c, null, null);
+                ImplCommonOps_DSCC.add(alpha, a, beta, b, c, null, null);
 
                 for (int row = 0; row < numRows; row++) {
                     for (int col = 0; col < numCols; col++) {
-                        double valA = a.get(row,col);
-                        double valB = b.get(row,col);
+                        double valA = a.get(row, col);
+                        double valB = b.get(row, col);
                         double found = alpha*valA + beta*valB;
 
-                        double expected = c.get(row,col);
+                        double expected = c.get(row, col);
 
-                        assertEquals(expected, found, UtilEjml.TEST_F64,row+" "+col);
+                        assertEquals(expected, found, UtilEjml.TEST_F64, row + " " + col);
                     }
                 }
                 assertTrue(CommonOps_DSCC.checkStructure(c));
@@ -103,35 +104,35 @@ public class TestImplCommonOps_DSCC {
         double alpha = 1.5;
         double beta = 2.3;
 
-        for( int numRows : new int[]{2,4,6,10}) {
-            DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(numRows,3,15, -1, 1, rand);
-            DMatrixSparseCSC b = RandomMatrices_DSCC.rectangle(numRows,4,15, -1, 1, rand);
-            DMatrixSparseCSC c = new DMatrixSparseCSC(numRows,0,0);
+        for (int numRows : new int[]{2, 4, 6, 10}) {
+            DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(numRows, 3, 15, -1, 1, rand);
+            DMatrixSparseCSC b = RandomMatrices_DSCC.rectangle(numRows, 4, 15, -1, 1, rand);
+            DMatrixSparseCSC c = new DMatrixSparseCSC(numRows, 0, 0);
 
 
-            ImplCommonOps_DSCC.addColAppend(alpha,a,1,beta,b,0,c, null);
+            ImplCommonOps_DSCC.addColAppend(alpha, a, 1, beta, b, 0, c, null);
             assertTrue(CommonOps_DSCC.checkStructure(c));
-            assertEquals(1,c.numCols);
+            assertEquals(1, c.numCols);
 
             for (int row = 0; row < numRows; row++) {
-                double valA = a.get(row,1);
-                double valB = b.get(row,0);
+                double valA = a.get(row, 1);
+                double valB = b.get(row, 0);
                 double found = alpha*valA + beta*valB;
 
-                double expected = c.get(row,0);
+                double expected = c.get(row, 0);
                 assertEquals(expected, found, UtilEjml.TEST_F64);
             }
 
-            ImplCommonOps_DSCC.addColAppend(alpha,a,2,beta,b,1,c, null);
+            ImplCommonOps_DSCC.addColAppend(alpha, a, 2, beta, b, 1, c, null);
             assertTrue(CommonOps_DSCC.checkStructure(c));
-            assertEquals(2,c.numCols);
+            assertEquals(2, c.numCols);
 
             for (int row = 0; row < numRows; row++) {
-                double valA = a.get(row,2);
-                double valB = b.get(row,1);
+                double valA = a.get(row, 2);
+                double valB = b.get(row, 1);
                 double found = alpha*valA + beta*valB;
 
-                double expected = c.get(row,1);
+                double expected = c.get(row, 1);
                 assertEquals(expected, found, UtilEjml.TEST_F64);
             }
         }
@@ -139,70 +140,70 @@ public class TestImplCommonOps_DSCC {
 
     @Test
     public void removeZeros_two() {
-        DMatrixSparseCSC A = new DMatrixSparseCSC(2,3,2);
+        DMatrixSparseCSC A = new DMatrixSparseCSC(2, 3, 2);
         A.indicesSorted = true;
-        A.set(0,1,0.1);
-        A.set(1,1,0.0);
-        A.set(1,2,0.3);
+        A.set(0, 1, 0.1);
+        A.set(1, 1, 0.0);
+        A.set(1, 2, 0.3);
         DMatrixSparseCSC A_orig = A.copy();
 
-        DMatrixSparseCSC B = new DMatrixSparseCSC(1,1,1);
+        DMatrixSparseCSC B = new DMatrixSparseCSC(1, 1, 1);
 
-        ImplCommonOps_DSCC.removeZeros(A,B,0);
+        ImplCommonOps_DSCC.removeZeros(A, B, 0);
         assertTrue(CommonOps_DSCC.checkStructure(B));
-        assertEquals(A.numRows,B.numRows);
-        assertEquals(A.numCols,B.numCols);
-        assertEquals(2,B.nz_length);
-        EjmlUnitTests.assertEquals(A,B,UtilEjml.TEST_F64);
-        assertTrue(MatrixFeatures_DSCC.isEquals(A,A_orig,UtilEjml.TEST_F64));
+        assertEquals(A.numRows, B.numRows);
+        assertEquals(A.numCols, B.numCols);
+        assertEquals(2, B.nz_length);
+        EjmlUnitTests.assertEquals(A, B, UtilEjml.TEST_F64);
+        assertTrue(MatrixFeatures_DSCC.isEquals(A, A_orig, UtilEjml.TEST_F64));
 
-        ImplCommonOps_DSCC.removeZeros(A,B,0.1);
-        assertEquals(1,B.nz_length);
-        assertEquals(0,B.get(0,1), UtilEjml.TEST_F64);
-        assertEquals(A.get(1,1),B.get(1,1),UtilEjml.TEST_F64);
-        assertTrue(MatrixFeatures_DSCC.isEquals(A,A_orig,UtilEjml.TEST_F64));
+        ImplCommonOps_DSCC.removeZeros(A, B, 0.1);
+        assertEquals(1, B.nz_length);
+        assertEquals(0, B.get(0, 1), UtilEjml.TEST_F64);
+        assertEquals(A.get(1, 1), B.get(1, 1), UtilEjml.TEST_F64);
+        assertTrue(MatrixFeatures_DSCC.isEquals(A, A_orig, UtilEjml.TEST_F64));
     }
 
     @Test
     public void removeZeros_one() {
-        DMatrixSparseCSC A = new DMatrixSparseCSC(2,3,2);
-        A.set(0,1,0.1);
-        A.set(1,1,0.0);
-        A.set(1,2,0.3);
+        DMatrixSparseCSC A = new DMatrixSparseCSC(2, 3, 2);
+        A.set(0, 1, 0.1);
+        A.set(1, 1, 0.0);
+        A.set(1, 2, 0.3);
 
-        ImplCommonOps_DSCC.removeZeros(A,0);
+        ImplCommonOps_DSCC.removeZeros(A, 0);
         assertTrue(CommonOps_DSCC.checkStructure(A));
-        assertEquals(A.numRows,2);
-        assertEquals(A.numCols,3);
-        assertEquals(2,A.nz_length);
-        assertEquals(0.1,A.get(0,1),UtilEjml.TEST_F64);
-        assertEquals(0.3,A.get(1,2),UtilEjml.TEST_F64);
+        assertEquals(A.numRows, 2);
+        assertEquals(A.numCols, 3);
+        assertEquals(2, A.nz_length);
+        assertEquals(0.1, A.get(0, 1), UtilEjml.TEST_F64);
+        assertEquals(0.3, A.get(1, 2), UtilEjml.TEST_F64);
 
-        ImplCommonOps_DSCC.removeZeros(A,0.1);
+        ImplCommonOps_DSCC.removeZeros(A, 0.1);
         assertTrue(CommonOps_DSCC.checkStructure(A));
-        assertEquals(A.numRows,2);
-        assertEquals(A.numCols,3);
-        assertEquals(1,A.nz_length);
-        assertEquals(0.3,A.get(1,2),UtilEjml.TEST_F64);
+        assertEquals(A.numRows, 2);
+        assertEquals(A.numCols, 3);
+        assertEquals(1, A.nz_length);
+        assertEquals(0.3, A.get(1, 2), UtilEjml.TEST_F64);
     }
 
     @Test
     public void removeZeros_one_random() {
         for (int i = 0; i < 40; i++) {
-            int rows = rand.nextInt(10)+1;
-            int cols = rand.nextInt(10)+1;
+            int rows = rand.nextInt(10) + 1;
+            int cols = rand.nextInt(10) + 1;
 
-            int nz = RandomMatrices_DSCC.nonzero(rows,cols,0.02,0.5,rand);
-            DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(rows,cols,nz,-1,1,rand);
+            int nz = RandomMatrices_DSCC.nonzero(rows, cols, 0.02, 0.5, rand);
+            DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(rows, cols, nz, -1, 1, rand);
 
-            ImplCommonOps_DSCC.removeZeros(A,0.2);
+            ImplCommonOps_DSCC.removeZeros(A, 0.2);
             assertTrue(CommonOps_DSCC.checkStructure(A));
-            assertEquals(A.numRows,rows);
-            assertEquals(A.numCols,cols);
+            assertEquals(A.numRows, rows);
+            assertEquals(A.numCols, cols);
             for (int j = 0; j < rows; j++) {
                 for (int k = 0; k < cols; k++) {
-                    double val = A.get(j,k);
-                    assertTrue(Math.abs(val) > 0.2 || val == 0,"val = "+val);
+                    double val = A.get(j, k);
+                    assertTrue(Math.abs(val) > 0.2 || val == 0, "val = " + val);
                 }
             }
         }
@@ -211,22 +212,22 @@ public class TestImplCommonOps_DSCC {
     @Test
     public void symmLowerToFull() {
         IGrowArray gw = new IGrowArray();
-        int[] sizes = {1,2,5,10};
+        int[] sizes = {1, 2, 5, 10};
 
         for (int i = 0; i < 20; i++) {
-            for( int N : sizes ) {
-                int nz = RandomMatrices_DSCC.nonzero(N,N/2,0.1,1.0,rand);
-                DMatrixSparseCSC A = RandomMatrices_DSCC.triangleLower(N,0,nz,-1,1,rand);
-                DMatrixSparseCSC B = new DMatrixSparseCSC(0,0);
+            for (int N : sizes) {
+                int nz = RandomMatrices_DSCC.nonzero(N, N/2, 0.1, 1.0, rand);
+                DMatrixSparseCSC A = RandomMatrices_DSCC.triangleLower(N, 0, nz, -1, 1, rand);
+                DMatrixSparseCSC B = new DMatrixSparseCSC(0, 0);
 
-                ImplCommonOps_DSCC.symmLowerToFull(A,B,gw);
+                ImplCommonOps_DSCC.symmLowerToFull(A, B, gw);
                 assertTrue(CommonOps_DSCC.checkStructure(B));
 
                 for (int row = 0; row < N; row++) {
                     for (int col = 0; col <= row; col++) {
 //                        System.out.println(row+" "+col);
-                        assertEquals(A.get(row,col), B.get(row,col), UtilEjml.TEST_F64);
-                        assertEquals(A.get(row,col), B.get(col,row), UtilEjml.TEST_F64);
+                        assertEquals(A.get(row, col), B.get(row, col), UtilEjml.TEST_F64);
+                        assertEquals(A.get(row, col), B.get(col, row), UtilEjml.TEST_F64);
                     }
                 }
             }
@@ -238,33 +239,53 @@ public class TestImplCommonOps_DSCC {
         IGrowArray gw = new IGrowArray();
         int[] sizes = {1, 2, 5, 10};
         for (int i = 0; i < 20; i++) {
-            for( int N : sizes ) {
-                DMatrixSparseTriplet triplet = RandomMatrices_DSTL.uniform(N,N,(N*N)/2,-1,1,rand);
-                DMatrixSparseCSC A = DConvertMatrixStruct.convert(triplet,(DMatrixSparseCSC)null);
+            for (int N : sizes) {
+                DMatrixSparseTriplet triplet = RandomMatrices_DSTL.uniform(N, N, (N*N)/2, -1, 1, rand);
+                DMatrixSparseCSC A = DConvertMatrixStruct.convert(triplet, (DMatrixSparseCSC)null);
                 DMatrixSparseCSC B = A.copy();
 
                 // first pass there should be no change
-                ImplCommonOps_DSCC.duplicatesAdd(B,null);
+                ImplCommonOps_DSCC.duplicatesAdd(B, null);
                 assertTrue(CommonOps_DSCC.checkStructure(B));
                 A.sortIndices(null);
                 B.sortIndices(null);
-                assertTrue(MatrixFeatures_DSCC.isEquals(A,B));
+                assertTrue(MatrixFeatures_DSCC.isEquals(A, B));
 
                 // Second pass there will be a lot of duplicates
                 int nz = triplet.nz_length;
                 for (int j = 0; j < nz; j++) {
                     int row = triplet.nz_rowcol.data[j*2];
-                    int col = triplet.nz_rowcol.data[j*2+1];
+                    int col = triplet.nz_rowcol.data[j*2 + 1];
                     double value = triplet.nz_value.data[j];
-                    triplet.addItem(row,col,value);
+                    triplet.addItem(row, col, value);
                 }
-                DConvertMatrixStruct.convert(triplet,B);
+                DConvertMatrixStruct.convert(triplet, B);
                 // Remove duplicates and see if B has elements that are twice the size of elements in A
-                ImplCommonOps_DSCC.duplicatesAdd(B,gw);
+                ImplCommonOps_DSCC.duplicatesAdd(B, gw);
                 assertTrue(CommonOps_DSCC.checkStructure(B));
-                CommonOps_DSCC.divide(B,2.0,B);
+                CommonOps_DSCC.divide(B, 2.0, B);
                 B.sortIndices(null);
                 assertTrue(MatrixFeatures_DSCC.isEquals(A, B, UtilEjml.TEST_F64));
+            }
+        }
+    }
+
+    @Test
+    public void select() {
+        int dim = 5;
+        DMatrixSparseCSC A = RandomMatrices_DSCC.rectangle(dim, dim, 10, 1, 2, rand);
+        DMatrixSparseCSC B = A.copy();
+
+        IPredicateBinary selector = IPredicatesBinary.higherTriangle;
+        ImplCommonOps_DSCC.select(B, B, selector);
+
+        for (int row = 0; row < dim; row++) {
+            for (int col = 0; col < dim; col++) {
+                if (selector.apply(row, col)) {
+                    assertEquals(A.get(row, col), B.get(row, col));
+                } else {
+                    assertFalse(B.isAssigned(row, col));
+                }
             }
         }
     }


### PR DESCRIPTION
A useful operator to f.i. (in-place) select only the lower triangle or diagonal of a matrix.
My use-case was the Triangle Count graph algorithm, implemented via a select + masked multiplication (to be added) + reduce.

A further idea would be to allow value-based selectors. I didn't need it, so I left it as a `TODO` for now. A value-based selector could be useful to remove zero entries or entries above/below a given threshold.