### PR TITLE
Introduce concept of Masks

### DIFF
--- a/main/autocode/src/org/ejml/GenerateJavaCode32.java
+++ b/main/autocode/src/org/ejml/GenerateJavaCode32.java
@@ -60,6 +60,8 @@ public class GenerateJavaCode32 extends GenerateCode32 {
         prefix32.add("FMonoids");
         prefix64.add("DSemiRings");
         prefix32.add("FSemiRings");
+        prefix64.add("DMask");
+        prefix32.add("FMask");
         prefix64.add("DScalar");
         prefix32.add("FScalar");
         prefix64.add("DMatrix");
@@ -100,6 +102,7 @@ public class GenerateJavaCode32 extends GenerateCode32 {
         converter.replacePattern("DOperator", "FOperator");
         converter.replacePattern("DMonoid", "FMonoid");
         converter.replacePattern("DSemiRing", "FSemiRing");
+        converter.replacePattern("DMask", "FMask");
         converter.replacePattern("DConvert", "FConvert");
         converter.replacePattern("DGrowArray", "FGrowArray");
         converter.replacePattern("DMatrix", "FMatrix");
@@ -140,6 +143,8 @@ public class GenerateJavaCode32 extends GenerateCode32 {
                 "main/ejml-core/test/org/ejml/data",
                 "main/ejml-core/src/org/ejml/ops",
                 "main/ejml-core/test/org/ejml/ops",
+                "main/ejml-core/src/org/ejml/masks",
+                "main/ejml-core/test/org/ejml/masks",
                 "main/ejml-experimental/src/org/ejml/dense/row/decomposition/bidiagonal/"
         };
 

--- a/main/ejml-core/src/org/ejml/masks/DMaskFactory.java
+++ b/main/ejml-core/src/org/ejml/masks/DMaskFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.masks;
+
+import org.ejml.data.DMatrixD1;
+import org.ejml.data.DMatrixSparseCSC;
+
+/**
+ * Utility class to get the corresponding mask builder based on a matrix or primitive array
+ */
+public class DMaskFactory {
+    public static DMaskPrimitive.Builder builder( double[] values ) {
+        return new DMaskPrimitive.Builder(values);
+    }
+
+    public static DMaskPrimitive.Builder builder( DMatrixD1 matrix ) {
+        return new DMaskPrimitive.Builder(matrix.data).withNumCols(matrix.numCols);
+    }
+
+    /**
+     * @param matrix Matrix to be used as a Mask
+     * @param structural Whether only the structure of the matrix is relevant or the actual value are considered
+     */
+    public static MaskBuilder builder( DMatrixSparseCSC matrix, boolean structural ) {
+        if (structural) {
+            return new DMaskSparseStructural.Builder(matrix);
+        } else {
+            return new DMaskSparse.Builder(matrix);
+        }
+    }
+}

--- a/main/ejml-core/src/org/ejml/masks/DMaskPrimitive.java
+++ b/main/ejml-core/src/org/ejml/masks/DMaskPrimitive.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.masks;
+
+/**
+ * Mask implementation backed by a primitive array
+ */
+public class DMaskPrimitive extends Mask {
+    // Values interpreted as a row-major dense matrix
+    private final double[] values;
+    /**
+     * Number of columns of the wrapped matrix
+     */
+    public final int numCols;
+    /**
+     * Value representing that the entry is not set in the mask
+     */
+    public final double zeroElement;
+
+    public DMaskPrimitive( double[] values, int numCols, boolean negated, double zeroElement ) {
+        // for dense structures they cannot be used for structural masks
+        super(negated);
+        this.values = values;
+        this.numCols = numCols;
+        this.zeroElement = zeroElement;
+    }
+
+    @Override
+    public boolean isSet( int row, int col ) {
+        // XOR as negated flips the mask flag
+        return negated ^ (values[row*numCols + col] != zeroElement);
+    }
+
+    @Override
+    public int getNumCols() {
+        return numCols;
+    }
+
+    @Override
+    public int getNumRows() {
+        return values.length/numCols;
+    }
+
+    @Override
+    public void setIndexColumn( int column ) {}
+
+    @Override
+    public boolean isSet( int index ) {
+        return negated ^ (values[index] != zeroElement);
+    }
+
+    /**
+     * Utility class to build {@link DMaskPrimitive}
+     */
+    public static class Builder extends MaskBuilder<DMaskPrimitive> {
+        private double[] values;
+        private int numCols = 1;
+        private double zeroElement = 0;
+
+        public Builder( double[] values ) {
+            this.values = values;
+        }
+
+        /**
+         * @param numCols Number of columns in the values
+         */
+        public Builder withNumCols( int numCols ) {
+            this.numCols = numCols;
+            return this;
+        }
+
+        /**
+         * @param zeroElement Value to represent the zero-element in the mask
+         */
+        public Builder withZeroElement( double zeroElement ) {
+            this.zeroElement = zeroElement;
+            return this;
+        }
+
+        @Override
+        public DMaskPrimitive build() {
+            return new DMaskPrimitive(values, numCols, negated, zeroElement);
+        }
+    }
+}

--- a/main/ejml-core/src/org/ejml/masks/DMaskSparse.java
+++ b/main/ejml-core/src/org/ejml/masks/DMaskSparse.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.masks;
+
+import org.ejml.data.DMatrixSparseCSC;
+import org.ejml.data.IGrowArray;
+import org.jetbrains.annotations.Nullable;
+
+import static org.ejml.UtilEjml.adjust;
+
+/**
+ * Mask implementation backed by a matrix in CSC format
+ */
+public class DMaskSparse extends Mask {
+    // Matrix to check for Mask.isSet(row, col)
+    protected final DMatrixSparseCSC matrix;
+    /**
+     * Value representing that the entry is not set in the mask
+     */
+    public final double zeroElement;
+    // Corresponding column to rowIndicesInIndexedColumn
+    private int indexedColumn = -1;
+    // Indexed row indices for the column specified in indexedColumn
+    // int[] instead of boolean[] to avoid clearing on multiple setActiveColumns()
+    // If the row is non-zero in the indexed column -> rowIndicesInIndexedColumn[row] == nz_index + 1
+    private int[] rowIndicesInIndexedColumn;
+
+    public DMaskSparse( DMatrixSparseCSC matrix, boolean negated, double zeroElement, @Nullable IGrowArray gw, boolean indexFirstColumn ) {
+        super(negated);
+        this.matrix = matrix;
+        this.zeroElement = zeroElement;
+        this.rowIndicesInIndexedColumn = adjust(gw, matrix.numRows);
+
+        if (indexFirstColumn) {
+            setIndexColumn(0);
+        }
+    }
+
+    @Override
+    public boolean isSet( int row, int col ) {
+        if (col != indexedColumn) {
+            return negated ^ (matrix.unsafe_get(row, col) != zeroElement);
+        } else {
+            return negated ^ (rowIndicesInIndexedColumn[row] - 1 == col);
+        }
+    }
+
+    @Override
+    public boolean isSet( int idx ) {
+        // assuming a column vector
+        return isSet(idx, 0);
+    }
+
+    @Override
+    public int getNumCols() {
+        return matrix.numCols;
+    }
+
+    @Override
+    public int getNumRows() {
+        return matrix.numRows;
+    }
+
+    @Override
+    public void setIndexColumn( int col ) {
+        if (indexedColumn != col) {
+            this.indexedColumn = col;
+            for (int i = matrix.col_idx[col]; i < matrix.col_idx[col + 1]; i++) {
+                if (matrix.nz_values[i] != zeroElement) {
+                    rowIndicesInIndexedColumn[matrix.nz_rows[i]] = col + 1;
+                }
+            }
+        }
+    }
+
+    /**
+     * Utility class to build {@link DMaskSparse}
+     */
+    public static class Builder extends MaskBuilder<DMaskSparse> {
+        private DMatrixSparseCSC matrix;
+        private double zeroElement = 0;
+        private boolean indexFirstColumn = false;
+        private @Nullable IGrowArray gw;
+
+        public Builder( DMatrixSparseCSC matrix ) {
+            this.matrix = matrix;
+        }
+
+        /**
+         * @param zeroElement Value to represent the zero-element in the mask
+         */
+        public Builder withZeroElement( double zeroElement ) {
+            this.zeroElement = zeroElement;
+            return this;
+        }
+
+        /**
+         * @param indexFirstColumn Whether the first column should be indexed on mask construction
+         */
+        public Builder withIndexFirstColumn( boolean indexFirstColumn ) {
+            this.indexFirstColumn = indexFirstColumn;
+            return this;
+        }
+
+        /**
+         * @param gw (Optional) Storage for internal workspace.  Can be null.
+         */
+        public Builder withWorkArray( IGrowArray gw ) {
+            this.gw = gw;
+            return this;
+        }
+
+        @Override
+        public DMaskSparse build() {
+            return new DMaskSparse(matrix, negated, zeroElement, gw, indexFirstColumn);
+        }
+    }
+}

--- a/main/ejml-core/src/org/ejml/masks/DMaskSparseStructural.java
+++ b/main/ejml-core/src/org/ejml/masks/DMaskSparseStructural.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.masks;
+
+import org.ejml.data.DMatrixSparseCSC;
+import org.ejml.data.IGrowArray;
+import org.jetbrains.annotations.Nullable;
+
+import static org.ejml.UtilEjml.adjust;
+
+/**
+ * Mask implementation which checks if the entry is assigned in the sparse matrix.
+ * The actual stored values are disregarded.
+ */
+public class DMaskSparseStructural extends Mask {
+    // TODO use a data-type-independent MatrixSparseCSC class
+    private final DMatrixSparseCSC matrix;
+    // Corresponding column to rowIndicesInIndexedColumn
+    private int indexedColumn = -1;
+    // int[] instead of boolean[] to avoid clearing on multiple setActiveColumns()
+    // If the row entry is non-zero in indexed column -> rowIndicesInIndexedColumn[row] == col
+    private int[] rowIndicesInIndexedColumn;
+
+    public DMaskSparseStructural( DMatrixSparseCSC matrix, boolean negated, @Nullable IGrowArray gw, boolean indexFirstColumn ) {
+        super(negated);
+        this.matrix = matrix;
+        this.rowIndicesInIndexedColumn = adjust(gw, matrix.numRows);
+        if (indexFirstColumn) {
+            setIndexColumn(0);
+        }
+    }
+
+    @Override
+    public boolean isSet( int row, int col ) {
+        if (col != indexedColumn) {
+            return negated ^ matrix.isAssigned(row, col);
+        } else {
+            return negated ^ (rowIndicesInIndexedColumn[row] - 1 == col);
+        }
+    }
+
+    @Override
+    public boolean isSet( int idx ) {
+        // assuming a column vector
+        return isSet(idx, 0);
+    }
+
+    @Override
+    public int getNumCols() {
+        return matrix.getNumCols();
+    }
+
+    @Override
+    public int getNumRows() {
+        return matrix.getNumRows();
+    }
+
+    @Override
+    public void setIndexColumn( int col ) {
+        if (indexedColumn != col) {
+            this.indexedColumn = col;
+            for (int i = matrix.col_idx[col]; i < matrix.col_idx[col + 1]; i++) {
+                rowIndicesInIndexedColumn[matrix.nz_rows[i]] = col + 1;
+            }
+        }
+    }
+
+    /**
+     * Utility class to build {@link DMaskSparseStructural}
+     */
+    public static class Builder extends MaskBuilder<DMaskSparseStructural> {
+        private DMatrixSparseCSC matrix;
+        private boolean indexFirstColumn;
+        private @Nullable IGrowArray gw;
+
+        public Builder( DMatrixSparseCSC matrix ) {
+            this.matrix = matrix;
+        }
+
+        /**
+         * @param indexFirstColumn Whether the first column should be indexed on mask construction
+         */
+        public Builder withIndexFirstColumn( boolean indexFirstColumn ) {
+            this.indexFirstColumn = indexFirstColumn;
+            return this;
+        }
+
+        /**
+         * @param gw (Optional) Storage for internal workspace.  Can be null.
+         */
+        public Builder withWorkArray( IGrowArray gw ) {
+            this.gw = gw;
+            return this;
+        }
+
+        @Override
+        public DMaskSparseStructural build() {
+            return new DMaskSparseStructural(matrix, negated, gw, indexFirstColumn);
+        }
+    }
+}

--- a/main/ejml-core/src/org/ejml/masks/Mask.java
+++ b/main/ejml-core/src/org/ejml/masks/Mask.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.masks;
+
+import lombok.Getter;
+import org.ejml.MatrixDimensionException;
+import org.ejml.data.Matrix;
+
+/**
+ * Mask used for specifying which matrix entries should be computed
+ */
+public abstract class Mask {
+    /**
+     * Whether the mask entries should be negated.
+     * This avoids materializing the actual negated matrix.
+     */
+    @Getter
+    public final boolean negated;
+
+    protected Mask( boolean negated ) {
+        this.negated = negated;
+    }
+
+    /**
+     * @return Whether the matrix entry is set in the mask
+     */
+    public abstract boolean isSet( int row, int col );
+
+    /**
+     * @return Whether the vector entry is set in the mask
+     */
+    public abstract boolean isSet( int idx );
+
+    /**
+     * @return The number of columns of the wrapped matrix
+     */
+    protected abstract int getNumCols();
+
+    /**
+     * @return The number of rows of the wrapped matrix
+     */
+    protected abstract int getNumRows();
+
+    /**
+     * Prints the mask to standard out.
+     **/
+    public void print() {
+        var result = new StringBuilder();
+        for (int row = 0; row < getNumRows(); row++) {
+            for (int col = 0; col < getNumCols(); col++) {
+                result.append(isSet(row, col) ? "+ " : "- ");
+            }
+            result.append(System.lineSeparator());
+        }
+
+        System.out.println(result);
+    }
+
+    /**
+     * For faster access on a specific column (on at a time)
+     * ! Only useful for sparse masks
+     *
+     * @param column column to index
+     */
+    public abstract void setIndexColumn( int column );
+
+    /**
+     * Checks whether the dimensions of the mask and matrix match
+     *
+     * @param matrix the mask is applied to
+     */
+    public void compatible( Matrix matrix ) {
+        if (matrix.getNumCols() != getNumCols() || matrix.getNumRows() != getNumRows()) {
+            throw new MatrixDimensionException(String.format(
+                    "Mask of (%d, %d) cannot be applied for matrix (%d, %d)",
+                    getNumRows(), getNumCols(), matrix.getNumCols(), matrix.getNumCols()
+            ));
+        }
+    }
+}

--- a/main/ejml-core/src/org/ejml/masks/MaskBuilder.java
+++ b/main/ejml-core/src/org/ejml/masks/MaskBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.masks;
+
+/**
+ * Helper class to build {@link Mask} and specify specific parameter
+ *
+ * @param <MASK> Type of Mask to return
+ */
+public abstract class MaskBuilder<MASK extends Mask> {
+    protected boolean negated = false;
+
+    /**
+     * @param negated whether the build mask should negate its entries
+     */
+    public MaskBuilder<MASK> withNegated( boolean negated ) {
+        this.negated = negated;
+        return this;
+    }
+
+    /**
+     * Build the mask based on the previously specified parameters
+     */
+    public abstract MASK build();
+}

--- a/main/ejml-core/test/org/ejml/masks/TestDMasksPrimitive.java
+++ b/main/ejml-core/test/org/ejml/masks/TestDMasksPrimitive.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.masks;
+
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.dense.row.RandomMatrices_DDRM;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestDMasksPrimitive {
+
+    @Test
+    void primitiveArray() {
+        double[] values = {2, 0, 4, 0, 0, -1};
+
+        DMaskPrimitive.Builder maskBuilder = DMaskFactory.builder(values);
+        DMaskPrimitive mask =  maskBuilder.withNegated(false).build();
+        DMaskPrimitive negated_mask = maskBuilder.withNegated(true).build();
+        boolean[] expected = {true, false, true, false, false, true};
+
+        for (int i = 0; i < values.length; i++) {
+            assertEquals(mask.isSet(i), expected[i]);
+            assertEquals(negated_mask.isSet(i), !expected[i]);
+        }
+    }
+
+    @Test
+    void denseMatrix() {
+        int dim = 20;
+        DMatrixRMaj matrix = RandomMatrices_DDRM.rectangle(dim, dim, new Random(42));
+
+        DMaskPrimitive.Builder maskBuilder = DMaskFactory.builder(matrix);
+        DMaskPrimitive mask =  maskBuilder.withNegated(false).build();
+        DMaskPrimitive negated_mask = maskBuilder.withNegated(true).build();
+
+        for (int row = 0; row < dim; row++) {
+            for (int col = 0; col < dim; col++) {
+                boolean expected = (matrix.get(row, col) != 0);
+                assertEquals(mask.isSet(row, col), expected);
+                assertEquals(negated_mask.isSet(row, col), !expected);
+            }
+        }
+    }
+}

--- a/main/ejml-core/test/org/ejml/masks/TestDMasksSparse.java
+++ b/main/ejml-core/test/org/ejml/masks/TestDMasksSparse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.masks;
+
+import org.ejml.data.DMatrixSparseCSC;
+import org.ejml.sparse.csc.RandomMatrices_DSCC;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestDMasksSparse {
+
+    @Test
+    void mask() {
+        int dim = 10;
+        DMatrixSparseCSC matrix = RandomMatrices_DSCC.rectangle(dim, dim, 50, new Random(42));
+
+        DMaskSparse.Builder builder = new DMaskSparse.Builder(matrix);
+        Mask mask = builder.withNegated(false).build();
+        Mask negated_mask = builder.withNegated(true).build();
+
+        for (int row = 0; row < dim; row++) {
+            for (int col = 0; col < dim; col++) {
+                boolean expected = (matrix.get(row, col) != 0);
+                assertEquals(mask.isSet(row, col), expected);
+                assertEquals(negated_mask.isSet(row, col), !expected);
+            }
+        }
+    }
+
+    @Test
+    void indexedMask() {
+        int dim = 10;
+        DMatrixSparseCSC matrix = RandomMatrices_DSCC.rectangle(dim, dim, 50, new Random(42));
+
+        DMaskSparse.Builder builder = new DMaskSparse.Builder(matrix);
+        Mask mask = builder.withNegated(false).build();
+        Mask negated_mask = builder.withNegated(true).build();
+
+        for (int col = 0; col < dim; col++) {
+            mask.setIndexColumn(col);
+            for (int row = 0; row < dim; row++) {
+                boolean expected = (matrix.get(row, col) != 0);
+                assertEquals(mask.isSet(row, col), expected);
+                assertEquals(negated_mask.isSet(row, col), !expected);
+            }
+        }
+    }
+}

--- a/main/ejml-core/test/org/ejml/masks/TestDMasksSparseStructural.java
+++ b/main/ejml-core/test/org/ejml/masks/TestDMasksSparseStructural.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.masks;
+
+import org.ejml.data.DMatrixSparseCSC;
+import org.ejml.sparse.csc.RandomMatrices_DSCC;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestDMasksSparseStructural {
+
+    @Test
+    void masks() {
+        int dim = 10;
+        DMatrixSparseCSC matrix = RandomMatrices_DSCC.rectangle(dim, dim, 50, new Random(42));
+
+        DMaskSparseStructural.Builder builder = new DMaskSparseStructural.Builder(matrix);
+        Mask mask = builder.withNegated(false).build();
+        Mask negated_mask = builder.withNegated(true).build();
+
+        for (int row = 0; row < dim; row++) {
+            for (int col = 0; col < dim; col++) {
+                boolean expected = matrix.isAssigned(row, col);
+                assertEquals(mask.isSet(row, col), expected);
+                assertEquals(negated_mask.isSet(row, col), !expected);
+            }
+        }
+    }
+
+    @Test
+    void indexedMask() {
+        int dim = 10;
+        DMatrixSparseCSC matrix = RandomMatrices_DSCC.rectangle(dim, dim, 50, new Random(42));
+
+        DMaskSparseStructural.Builder builder = new DMaskSparseStructural.Builder(matrix);
+        Mask mask = builder.withNegated(false).build();
+        Mask negated_mask = builder.withNegated(true).build();
+
+        for (int col = 0; col < dim; col++) {
+            mask.setIndexColumn(col);
+            for (int row = 0; row < dim; row++) {
+                boolean expected = matrix.isAssigned(row, col);
+                assertEquals(mask.isSet(row, col), expected);
+                assertEquals(negated_mask.isSet(row, col), !expected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implementation was evaluated as part of my thesis.
Besides Semirings, masks are an important concept of GraphBLAS.

Masks are useful to only compute relevant entries in the result. Compared to offsets, masks allow for arbitrary patterns.
For each result entry, it is checked if mask the entry is set in the mask (`Mask::isSet`). 
For sparse results, this is also useful to avoid large intermediate results. An example use-case is masked mxm for Triangle Count.

In this PR, as an example, the mask is added to dense-vector sparse-matrix multiplication.

(*An idea would be to remove the offsets in these operations as an offset could be specified via a mask.
Therefore I would add a Mask not backed by a matrix but a predicate like `idx > 5`. This would simplify the method signature but also be definitly slower.)

Further planned PRs are:
* Masks in sparse operations
* Mask backed by function instead of matrix

In the future I also plan to add an entry iterator for the mask. This will allow to explicitly only compute the entries set in the mask instead of checking each possible result entry. To chose which strategy to use, the mask should also optionally return its number of non-zero entries (relevant for sparse matrices).

I assume @szarnyasg will be interested in this PR.
Maybe also @breandan or @maxindelicato?