### PR TITLE
Apply spotless

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,25 +1,25 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
- *
- * This file is part of Efficient Java Matrix Library (EJML).
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+*
+* This file is part of Efficient Java Matrix Library (EJML).
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 dependencies {
-    compile project(':main:ejml-all')
+	compile project(':main:ejml-all')
 
-    ['core','generator-annprocess'].each { String a->
-        compile('org.openjdk.jmh:jmh-'+a+':1.27')
-    }
+	['core','generator-annprocess'].each { String a->
+		compile('org.openjdk.jmh:jmh-'+a+':1.27')
+	}
 }

--- a/main/autocode/build.gradle
+++ b/main/autocode/build.gradle
@@ -1,36 +1,36 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
- *
- * This file is part of Efficient Java Matrix Library (EJML).
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+*
+* This file is part of Efficient Java Matrix Library (EJML).
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 dependencies {
-    compile group: 'com.peterabeles', name: 'auto64fto32f', version: '2.1'
+	compile group: 'com.peterabeles', name: 'auto64fto32f', version: '2.1'
 }
 
 gversion {
-    srcDir = "../ejml-core/src"
-    classPackage = "org.ejml"
-    className = "EjmlVersion"
-    indent = "    "
-    annotate = true
+	srcDir = "../ejml-core/src"
+	classPackage = "org.ejml"
+	className = "EjmlVersion"
+	indent = "    "
+	annotate = true
 }
 
 task(autogenerate, dependsOn: 'classes', type: JavaExec) {
-    main = 'org.ejml.MasterCodeGenerator'
-    classpath = sourceSets.main.runtimeClasspath
+	main = 'org.ejml.MasterCodeGenerator'
+	classpath = sourceSets.main.runtimeClasspath
 }
 
 // Create the EjmlVersion file only when the autogenerate command is called. This speeds up build time significantly.

--- a/main/ejml-core/src/org/ejml/EjmlParameters.java
+++ b/main/ejml-core/src/org/ejml/EjmlParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 /**

--- a/main/ejml-core/src/org/ejml/EjmlUnitTests.java
+++ b/main/ejml-core/src/org/ejml/EjmlUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.data.*;

--- a/main/ejml-core/src/org/ejml/FancyPrint.java
+++ b/main/ejml-core/src/org/ejml/FancyPrint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.ops.MatrixIO;

--- a/main/ejml-core/src/org/ejml/LinearSolverSafe.java
+++ b/main/ejml-core/src/org/ejml/LinearSolverSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.data.ReshapeMatrix;

--- a/main/ejml-core/src/org/ejml/LinearSolverSparseSafe.java
+++ b/main/ejml-core/src/org/ejml/LinearSolverSparseSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.data.DMatrixSparse;

--- a/main/ejml-core/src/org/ejml/LinearSolverToSparse.java
+++ b/main/ejml-core/src/org/ejml/LinearSolverToSparse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.data.Matrix;

--- a/main/ejml-core/src/org/ejml/MatrixDimensionException.java
+++ b/main/ejml-core/src/org/ejml/MatrixDimensionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 /**

--- a/main/ejml-core/src/org/ejml/UtilEjml.java
+++ b/main/ejml-core/src/org/ejml/UtilEjml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.data.*;

--- a/main/ejml-core/src/org/ejml/data/BMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/BMatrixRMaj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import java.util.Arrays;

--- a/main/ejml-core/src/org/ejml/data/ComplexPolar_F64.java
+++ b/main/ejml-core/src/org/ejml/data/ComplexPolar_F64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import lombok.Data;

--- a/main/ejml-core/src/org/ejml/data/Complex_F64.java
+++ b/main/ejml-core/src/org/ejml/data/Complex_F64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import lombok.Data;

--- a/main/ejml-core/src/org/ejml/data/DGrowArray.java
+++ b/main/ejml-core/src/org/ejml/data/DGrowArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 /**

--- a/main/ejml-core/src/org/ejml/data/DMatrix.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 /**

--- a/main/ejml-core/src/org/ejml/data/DMatrix1Row.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix1Row.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 /**

--- a/main/ejml-core/src/org/ejml/data/DMatrix2.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -132,4 +131,3 @@ public class DMatrix2 implements DMatrixFixed {
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}
 }
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix2x2.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix2x2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -139,4 +138,3 @@ public class DMatrix2x2 implements DMatrixFixed {
     @Override public <T extends Matrix> T createLike() {return (T)new DMatrix2x2();}
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}}
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix3.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -143,4 +142,3 @@ public class DMatrix3 implements DMatrixFixed {
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}
 }
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix3x3.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix3x3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -176,4 +175,3 @@ public class DMatrix3x3 implements DMatrixFixed {
     @Override public <T extends Matrix> T createLike() {return (T)new DMatrix3x3();}
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}}
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix4.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -154,4 +153,3 @@ public class DMatrix4 implements DMatrixFixed {
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}
 }
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix4x4.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix4x4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -223,4 +222,3 @@ public class DMatrix4x4 implements DMatrixFixed {
     @Override public <T extends Matrix> T createLike() {return (T)new DMatrix4x4();}
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}}
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix5.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -165,4 +164,3 @@ public class DMatrix5 implements DMatrixFixed {
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}
 }
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix5x5.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix5x5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -280,4 +279,3 @@ public class DMatrix5x5 implements DMatrixFixed {
     @Override public <T extends Matrix> T createLike() {return (T)new DMatrix5x5();}
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}}
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix6.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -176,4 +175,3 @@ public class DMatrix6 implements DMatrixFixed {
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}
 }
-

--- a/main/ejml-core/src/org/ejml/data/DMatrix6x6.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix6x6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -347,4 +346,3 @@ public class DMatrix6x6 implements DMatrixFixed {
     @Override public <T extends Matrix> T createLike() {return (T)new DMatrix6x6();}
 
     @Override public MatrixType getType() {return MatrixType.UNSPECIFIED;}}
-

--- a/main/ejml-core/src/org/ejml/data/DMatrixD1.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixD1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/data/DMatrixRBlock.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.EjmlParameters;

--- a/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;

--- a/main/ejml-core/src/org/ejml/data/ElementLocation.java
+++ b/main/ejml-core/src/org/ejml/data/ElementLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import lombok.Data;

--- a/main/ejml-core/src/org/ejml/data/IGrowArray.java
+++ b/main/ejml-core/src/org/ejml/data/IGrowArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 /**

--- a/main/ejml-core/src/org/ejml/data/Matrix.java
+++ b/main/ejml-core/src/org/ejml/data/Matrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import java.io.Serializable;

--- a/main/ejml-core/src/org/ejml/data/ZMatrixD1.java
+++ b/main/ejml-core/src/org/ejml/data/ZMatrixD1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.MatrixDimensionException;

--- a/main/ejml-core/src/org/ejml/data/ZMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/ZMatrixRMaj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/ops/CommonOps_BDRM.java
+++ b/main/ejml-core/src/org/ejml/ops/CommonOps_BDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.data.BMatrixRMaj;

--- a/main/ejml-core/src/org/ejml/ops/ComplexMath_F64.java
+++ b/main/ejml-core/src/org/ejml/ops/ComplexMath_F64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/ops/ConvertMatrixData.java
+++ b/main/ejml-core/src/org/ejml/ops/ConvertMatrixData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.data.*;

--- a/main/ejml-core/src/org/ejml/ops/ConvertMatrixType.java
+++ b/main/ejml-core/src/org/ejml/ops/ConvertMatrixType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.data.*;

--- a/main/ejml-core/src/org/ejml/ops/DConvertArrays.java
+++ b/main/ejml-core/src/org/ejml/ops/DConvertArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/ops/DConvertMatrixStruct.java
+++ b/main/ejml-core/src/org/ejml/ops/DConvertMatrixStruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/ops/DMonoid.java
+++ b/main/ejml-core/src/org/ejml/ops/DMonoid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/DMonoids.java
+++ b/main/ejml-core/src/org/ejml/ops/DMonoids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/DOperatorBinary.java
+++ b/main/ejml-core/src/org/ejml/ops/DOperatorBinary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/DOperatorBinaryIdx.java
+++ b/main/ejml-core/src/org/ejml/ops/DOperatorBinaryIdx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/DOperatorUnary.java
+++ b/main/ejml-core/src/org/ejml/ops/DOperatorUnary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/DSemiRing.java
+++ b/main/ejml-core/src/org/ejml/ops/DSemiRing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/DSemiRings.java
+++ b/main/ejml-core/src/org/ejml/ops/DSemiRings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import static org.ejml.ops.DMonoids.*;

--- a/main/ejml-core/src/org/ejml/ops/MatrixFeatures_D.java
+++ b/main/ejml-core/src/org/ejml/ops/MatrixFeatures_D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-core/src/org/ejml/ops/MatrixIO.java
+++ b/main/ejml-core/src/org/ejml/ops/MatrixIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.EjmlVersion;

--- a/main/ejml-core/src/org/ejml/ops/QuickSort_S32.java
+++ b/main/ejml-core/src/org/ejml/ops/QuickSort_S32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/ops/ReadCsv.java
+++ b/main/ejml-core/src/org/ejml/ops/ReadCsv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.jetbrains.annotations.Nullable;

--- a/main/ejml-core/src/org/ejml/ops/SortCoupledArray_F64.java
+++ b/main/ejml-core/src/org/ejml/ops/SortCoupledArray_F64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 /**

--- a/main/ejml-core/src/org/ejml/sparse/ComputePermutation.java
+++ b/main/ejml-core/src/org/ejml/sparse/ComputePermutation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse;
 
 import org.ejml.data.IGrowArray;

--- a/main/ejml-ddense/src/org/ejml/dense/block/MatrixOps_DDRB.java
+++ b/main/ejml-ddense/src/org/ejml/dense/block/MatrixOps_DDRB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.block;
 
 import org.ejml.EjmlParameters;

--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row;
 
 import org.ejml.EjmlParameters;

--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_MT_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_MT_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row;
 
 import org.ejml.EjmlParameters;

--- a/main/ejml-ddense/src/org/ejml/dense/row/EigenOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/EigenOps_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/RandomMatrices_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/RandomMatrices_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row;
 
 import org.ejml.data.BMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/bidiagonal/BidiagonalDecompositionTall_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/bidiagonal/BidiagonalDecompositionTall_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.bidiagonal;
 
 import org.ejml.data.DMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/chol/CholeskyDecompositionLDL_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/chol/CholeskyDecompositionLDL_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.chol;
 
 import org.ejml.data.DMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/eig/EigenPowerMethod_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/eig/EigenPowerMethod_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.eig;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/eig/SwitchingEigenDecomposition_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/eig/SwitchingEigenDecomposition_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.eig;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/eig/watched/WatchedDoubleStepQREigen_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/eig/watched/WatchedDoubleStepQREigen_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.eig.watched;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/hessenberg/TridiagonalDecompositionHouseholderOrig_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/hessenberg/TridiagonalDecompositionHouseholderOrig_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.hessenberg;
 
 import org.ejml.data.DMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/lu/LUDecompositionBase_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/lu/LUDecompositionBase_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/qr/QRDecompositionHouseholder_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/qr/QRDecompositionHouseholder_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.qr;
 
 import org.ejml.data.DMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/qr/QrUpdate_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/qr/QrUpdate_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.qr;
 
 import org.ejml.data.DMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/svd/SafeSvd_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/svd/SafeSvd_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.svd;
 
 import org.ejml.data.DMatrixRMaj;

--- a/main/ejml-ddense/src/org/ejml/dense/row/decomposition/svd/SvdImplicitQrDecompose_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/decomposition/svd/SvdImplicitQrDecompose_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decomposition.svd;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/chol/LinearSolverCholLDL_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/chol/LinearSolverCholLDL_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.chol;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/chol/LinearSolverChol_DDRB.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/chol/LinearSolverChol_DDRB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.chol;
 
 import org.ejml.data.DMatrixRBlock;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/chol/LinearSolverChol_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/chol/LinearSolverChol_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.chol;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/lu/LinearSolverLuKJI_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/lu/LinearSolverLuKJI_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/lu/LinearSolverLu_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/lu/LinearSolverLu_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseCol_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseCol_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseCol_MT_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseCol_MT_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseTran_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseTran_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouse_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouse_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQr_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQr_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrpHouseCol_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrpHouseCol_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/linsol/svd/SolvePseudoInverseSvd_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/linsol/svd/SolvePseudoInverseSvd_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.svd;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOpsWithSemiRing_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOpsWithSemiRing_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc;
 
 import org.ejml.MatrixDimensionException;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc;
 
 import org.ejml.MatrixDimensionException;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_MT_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/CommonOps_MT_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc;
 
 import org.ejml.MatrixDimensionException;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/RandomMatrices_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/RandomMatrices_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/chol/CholeskyUpLooking_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/chol/CholeskyUpLooking_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.decomposition.chol;
 
 import org.ejml.data.Complex_F64;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/lu/LuUpLooking_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/lu/LuUpLooking_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.decomposition.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/qr/QrLeftLookingDecomposition_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/qr/QrLeftLookingDecomposition_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.decomposition.qr;
 
 import org.ejml.data.DGrowArray;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/chol/LinearSolverCholesky_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/chol/LinearSolverCholesky_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.linsol.chol;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/lu/LinearSolverLu_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/lu/LinearSolverLu_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.linsol.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/qr/LinearSolverQrLeftLooking_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/qr/LinearSolverQrLeftLooking_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOpsWithSemiRing_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOpsWithSemiRing_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.misc;
 
 import org.ejml.data.DGrowArray;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOps_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOps_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.misc;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOps_MT_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ImplCommonOps_MT_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.misc;
 
 import org.ejml.concurrency.EjmlConcurrency;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplMultiplicationWithSemiRing_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplMultiplicationWithSemiRing_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.mult;
 
 import org.ejml.data.DGrowArray;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplMultiplication_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplMultiplication_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.mult;
 
 import org.ejml.data.DGrowArray;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplMultiplication_MT_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/mult/ImplMultiplication_MT_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.sparse.csc.mult;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-simple/src/org/ejml/equation/Equation.java
+++ b/main/ejml-simple/src/org/ejml/equation/Equation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.equation;
 
 import org.ejml.data.*;

--- a/main/ejml-simple/src/org/ejml/equation/Operation.java
+++ b/main/ejml-simple/src/org/ejml/equation/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.equation;
 
 import org.ejml.MatrixDimensionException;

--- a/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.data.*;

--- a/main/ejml-simple/src/org/ejml/simple/SimpleSVD.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleSVD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple.ops;
 
 import org.ejml.data.*;

--- a/main/ejml-zdense/src/org/ejml/dense/row/CommonOps_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/CommonOps_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row;
 
 import org.ejml.EjmlParameters;

--- a/main/ejml-zdense/src/org/ejml/dense/row/decompose/lu/LUDecompositionBase_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/decompose/lu/LUDecompositionBase_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decompose.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-zdense/src/org/ejml/dense/row/decompose/qr/QRDecompositionHouseholder_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/decompose/qr/QRDecompositionHouseholder_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.decompose.qr;
 
 import org.ejml.data.Complex_F64;

--- a/main/ejml-zdense/src/org/ejml/dense/row/linsol/chol/LinearSolverChol_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/linsol/chol/LinearSolverChol_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.chol;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-zdense/src/org/ejml/dense/row/linsol/lu/LinearSolverLu_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/linsol/lu/LinearSolverLu_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.lu;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseCol_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseCol_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseTran_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouseTran_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouse_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQrHouse_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQr_ZDRM.java
+++ b/main/ejml-zdense/src/org/ejml/dense/row/linsol/qr/LinearSolverQr_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.linsol.qr;
 
 import org.ejml.UtilEjml;

--- a/regression/build.gradle
+++ b/regression/build.gradle
@@ -1,37 +1,37 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
- *
- * This file is part of Efficient Java Matrix Library (EJML).
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+*
+* This file is part of Efficient Java Matrix Library (EJML).
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 dependencies {
-    compile project(':main:autocode')
-    compile project(':main:ejml-all')
-    compile project(':main:ejml-cdense').sourceSets.benchmarks.output
-    compile project(':main:ejml-ddense').sourceSets.benchmarks.output
-    compile project(':main:ejml-dsparse').sourceSets.benchmarks.output
-    compile project(':main:ejml-fdense').sourceSets.benchmarks.output
-    compile project(':main:ejml-fsparse').sourceSets.benchmarks.output
-    compile project(':main:ejml-zdense').sourceSets.benchmarks.output
+	compile project(':main:autocode')
+	compile project(':main:ejml-all')
+	compile project(':main:ejml-cdense').sourceSets.benchmarks.output
+	compile project(':main:ejml-ddense').sourceSets.benchmarks.output
+	compile project(':main:ejml-dsparse').sourceSets.benchmarks.output
+	compile project(':main:ejml-fdense').sourceSets.benchmarks.output
+	compile project(':main:ejml-fsparse').sourceSets.benchmarks.output
+	compile project(':main:ejml-zdense').sourceSets.benchmarks.output
 
-    ['core','generator-annprocess'].each { String a->
-        compile('org.openjdk.jmh:jmh-'+a+':1.27')
-    }
+	['core','generator-annprocess'].each { String a->
+		compile('org.openjdk.jmh:jmh-'+a+':1.27')
+	}
 
-    compile group: 'args4j', name: 'args4j', version: '2.33'
-    compile 'com.sun.mail:javax.mail:1.6.0'
+	compile group: 'args4j', name: 'args4j', version: '2.33'
+	compile 'com.sun.mail:javax.mail:1.6.0'
 }
 
 // Run the regression using a gradle command
@@ -39,12 +39,12 @@ dependencies {
 //
 // Example: ./gradlew runtimeRegression run --console=plain -Dexec.args="--SummaryOnly"
 task runtimeRegression(type: JavaExec) {
-    dependsOn build
-    group = "Execution"
-    description = "Run the mainClass from the output jar in classpath with ExecTask"
-    classpath = sourceSets.main.runtimeClasspath
-    main = "org.ejml.RuntimeRegressionMasterApp"
-    args System.getProperty("exec.args", "").split()
+	dependsOn build
+	group = "Execution"
+	description = "Run the mainClass from the output jar in classpath with ExecTask"
+	classpath = sourceSets.main.runtimeClasspath
+	main = "org.ejml.RuntimeRegressionMasterApp"
+	args System.getProperty("exec.args", "").split()
 }
 
 // Creating a jar would be easier to pass in arguments with, but it seems like only the first


### PR DESCRIPTION
I didn't want to have these changes in #118.
To note is, that the `build.gradle` files still has the wrong year in the copyright.