### PR TITLE
Fix `getNumElements` for sparse matrix formats

### DIFF
--- a/main/ejml-core/src/org/ejml/data/DMatrix.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 /**
@@ -73,5 +72,7 @@ public interface DMatrix extends Matrix {
      *
      * @return Number of elements in this matrix.
      */
-    int getNumElements();
+    default int getNumElements() {
+        return getNumRows() * getNumCols();
+    }
 }

--- a/main/ejml-core/src/org/ejml/data/DMatrixRBlock.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.EjmlParameters;
@@ -178,11 +177,6 @@ public class DMatrixRBlock extends DMatrixD1 {
                 }
             }
         }
-    }
-
-    @Override
-    public int getNumElements() {
-        return numRows*numCols;
     }
 
     @Override

--- a/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.UtilEjml;
@@ -284,17 +283,6 @@ public class DMatrixRMaj extends DMatrix1Row {
      */
     public boolean isInBounds( int row  , int col ) {
         return( col >= 0 && col < numCols && row >= 0 && row < numRows );
-    }
-
-    /**
-     * Returns the number of elements in this matrix, which is equal to
-     * the number of rows times the number of columns.
-     *
-     * @return The number of elements in the matrix.
-     */
-    @Override
-    public int getNumElements() {
-        return numRows*numCols;
     }
 
     /**

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.UtilEjml;
@@ -311,7 +310,7 @@ public class DMatrixSparseCSC implements DMatrixSparse {
 
     @Override
     public int getNumElements() {
-        return nz_length;
+        return numCols * numRows;
     }
 
     @Override

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -496,9 +496,4 @@ public class DMatrixSparseCSC implements DMatrixSparse {
             }
         };
     }
-
-    @Override
-    public int getNonZeroCount() {
-        return nz_length;
-    }
 }

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -309,11 +309,6 @@ public class DMatrixSparseCSC implements DMatrixSparse {
     }
 
     @Override
-    public int getNumElements() {
-        return numCols * numRows;
-    }
-
-    @Override
     public void reshape( int numRows, int numCols, int arrayLength ) {
         // OK so technically it is sorted, but forgetting to correctly set this flag is a common mistake so
         // decided to be conservative and mark it as unsorted so that stuff doesn't blow up

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 import org.ejml.ops.MatrixIO;
@@ -177,7 +176,7 @@ public class DMatrixSparseTriplet implements DMatrixSparse {
 
     @Override
     public int getNumElements() {
-        return nz_length;
+        return numCols * numRows;
     }
 
     /**

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -387,9 +387,4 @@ public class DMatrixSparseTriplet implements DMatrixSparse {
             }
         };
     }
-
-    @Override
-    public int getNonZeroCount() {
-        return nz_length;
-    }
 }

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -174,11 +174,6 @@ public class DMatrixSparseTriplet implements DMatrixSparse {
         }
     }
 
-    @Override
-    public int getNumElements() {
-        return numCols * numRows;
-    }
-
     /**
      * Searches the list to see if the element at (row,col) has been assigned. The worst case runtime for this
      * operation is O(N), where N is the number of elements in the matrix.

--- a/main/ejml-core/src/org/ejml/data/MatrixSparse.java
+++ b/main/ejml-core/src/org/ejml/data/MatrixSparse.java
@@ -71,11 +71,6 @@ public interface MatrixSparse extends ReshapeMatrix {
     boolean isAssigned( int row , int col );
 
     /**
-     * Returns number of non-zero values
-     */
-    int getNonZeroCount();
-
-    /**
      * Sets all elements to zero by removing the sparse graph
      */
     @Override

--- a/main/ejml-core/src/org/ejml/data/MatrixSparse.java
+++ b/main/ejml-core/src/org/ejml/data/MatrixSparse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.data;
 
 /**

--- a/main/ejml-core/test/org/ejml/data/GenericTestsDMatrixSparse.java
+++ b/main/ejml-core/test/org/ejml/data/GenericTestsDMatrixSparse.java
@@ -197,7 +197,7 @@ public abstract class GenericTestsDMatrixSparse extends GenericTestsDMatrix
     public void reshape() {
         DMatrixSparse m = (DMatrixSparse)createMatrix(3,4);
         m.reshape(2,4,8);
-        assertEquals(0,m.getNumElements());
+        assertEquals(0,m.getNonZeroLength());
         assertEquals(2,m.getNumRows());
         assertEquals(4,m.getNumCols());
     }

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/TestCommonOps_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/TestCommonOps_DSCC.java
@@ -1518,7 +1518,7 @@ public class TestCommonOps_DSCC {
         double result = CommonOps_DSCC.reduceScalar(A, 0, Double::sum);
 
         double expectedResult = 0;
-        for (int i = 0; i < A.getNumElements(); i++) {
+        for (int i = 0; i < A.getNonZeroLength(); i++) {
             expectedResult += A.nz_values[i];
         }
 

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/misc/TestImplCommonOpsWithSemiRing_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/misc/TestImplCommonOpsWithSemiRing_DSCC.java
@@ -50,7 +50,7 @@ public class TestImplCommonOpsWithSemiRing_DSCC {
 
         double[] found = new double[]{c.get(0, 0), c.get(1, 1)};
 
-        assertTrue(c.getNumElements() == 2);
+        assertTrue(c.getNonZeroLength() == 2);
         assertTrue(Arrays.equals(expected, found));
     }
 
@@ -73,7 +73,7 @@ public class TestImplCommonOpsWithSemiRing_DSCC {
 
         ImplCommonOpsWithSemiRing_DSCC.elementMult(matrix, otherMatrix, result, semiRing, null, null);
 
-        assertEquals(2, result.getNumElements());
+        assertEquals(2, result.getNonZeroLength());
         assertTrue(expected[0] == result.get(1, 1));
         assertTrue(expected[1] == result.get(1, 2));
     }

--- a/main/ejml-experimental/src/org/ejml/data/BlockD3Matrix64F.java
+++ b/main/ejml-experimental/src/org/ejml/data/BlockD3Matrix64F.java
@@ -136,11 +136,6 @@ public class BlockD3Matrix64F implements ReshapeMatrix, DMatrix {
     }
 
     @Override
-    public int getNumElements() {
-        return numRows*numCols;
-    }
-
-    @Override
     public void print() {
         MatrixIO.print(System.out,this);
     }

--- a/main/ejml-experimental/src/org/ejml/data/DenseD2Matrix64F.java
+++ b/main/ejml-experimental/src/org/ejml/data/DenseD2Matrix64F.java
@@ -96,11 +96,6 @@ public class DenseD2Matrix64F implements Serializable, ReshapeMatrix, DMatrix {
     }
 
     @Override
-    public int getNumElements() {
-        return numRows*numCols;
-    }
-
-    @Override
     public int getNumRows() {
         return numRows;
     }


### PR DESCRIPTION
Also removing redundant and unused `getNonZeroCount` in favor of `getNonZeroLength`. Maybe `getNonZeroLength` is to implementation specific and `getNonZeroCount` would be the better choice.

One could argue about the naming still, as the stored entries can actually be zero. So, `getStoredNumberOfElements` might be more readable but also more verbose. Also it would unnecessarily break the API so I refrained from any renaming.

Fixes #122 