### PR TITLE
Add shiftRowsUp/shiftRowsDown methods

### DIFF
--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -2771,7 +2771,7 @@ public class CommonOps_DDRM {
     }
 
     /**
-     * Fill all rows in the specified range with zeros
+     * Fills all rows in the specified range with zeros
      *
      * @param start Index of the first row (inclusivce) to be filled
      * @param end Index of the last row (exclusive) to be filled
@@ -2781,10 +2781,11 @@ public class CommonOps_DDRM {
     }
 
     /**
-     * Shifts all rows up by the specified number of places
+     * Shifts all elements up by the specified number of rows.
+     * Vacated rows are set to zero.
      *
      * @param a A matrix. Modified.
-     * @param c The rows are shifted by this number.
+     * @param c Number of rows to shift by.
      */
     public static void shiftRowsUp(DMatrixRMaj a, int c) {
         if (c < a.numRows) {
@@ -2796,10 +2797,11 @@ public class CommonOps_DDRM {
     }
 
     /**
-     * Shifts all rows down by the specified number of places
+     * Shifts all elements down by the specified number of rows
+     * Vacated rows are set to zero.
      *
      * @param a A matrix. Modified.
-     * @param c The rows are shifted by this number.
+     * @param c Number of rows to shift by.
      */
     public static void shiftRowsDown(DMatrixRMaj a, int c) {
         if (c < a.numRows) {

--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -2771,6 +2771,46 @@ public class CommonOps_DDRM {
     }
 
     /**
+     * Fill all rows in the specified range with zeros
+     *
+     * @param start Index of the first row (inclusivce) to be filled
+     * @param end Index of the last row (exclusive) to be filled
+     */
+    public static void zeroRows(DMatrixRMaj a, int start, int end) {
+        Arrays.fill(a.data, start * a.numCols, end * a.numCols, 0);
+    }
+
+    /**
+     * Shifts all rows up by the specified number of places
+     *
+     * @param a A matrix. Modified.
+     * @param c The rows are shifted by this number.
+     */
+    public static void shiftRowsUp(DMatrixRMaj a, int c) {
+        if (c < a.numRows) {
+            System.arraycopy(a.data, c * a.numCols, a.data, 0, (a.numRows - c) * a.numCols);
+            zeroRows(a, a.numRows - c, a.numRows);
+        } else {
+            a.zero();
+        }
+    }
+
+    /**
+     * Shifts all rows down by the specified number of places
+     *
+     * @param a A matrix. Modified.
+     * @param c The rows are shifted by this number.
+     */
+    public static void shiftRowsDown(DMatrixRMaj a, int c) {
+        if (c < a.numRows) {
+            System.arraycopy(a.data, 0, a.data, c * a.numCols, (a.numRows - c) * a.numCols);
+            zeroRows(a, 0, c);
+        } else {
+            a.zero();
+        }
+    }
+
+    /**
      * <p>Performs absolute value of a matrix:<br>
      * <br>
      * c = abs(a)<br>

--- a/main/ejml-ddense/test/org/ejml/dense/row/TestCommonOps_DDRM.java
+++ b/main/ejml-ddense/test/org/ejml/dense/row/TestCommonOps_DDRM.java
@@ -922,6 +922,50 @@ public class TestCommonOps_DDRM {
     }
 
     @Test
+    public void shiftRowsUp() {
+        DMatrixRMaj A = RandomMatrices_DDRM.rectangle(5, 6, 0, 1, rand);
+
+        DMatrixRMaj B = new DMatrixRMaj(5, 6);
+
+        for (int n = 0; n <= A.numRows; n++) {
+            B.set(A);
+            CommonOps_DDRM.shiftRowsUp(B, n);
+            for (int row = 0; row < A.numRows - n; row++) {
+                for (int col = 0; col < A.numCols; col++) {
+                    assertEquals(A.get(row + n, col), B.get(row, col), UtilEjml.TEST_F64);
+                }
+            }
+            for (int row = A.numRows - n; row < A.numRows; row++) {
+                for (int col = 0; col < A.numCols; col++) {
+                    assertEquals(0.0, B.get(row, col), UtilEjml.TEST_F64);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shiftRowsDown() {
+        DMatrixRMaj A = RandomMatrices_DDRM.rectangle(5, 6, 0, 1, rand);
+
+        DMatrixRMaj B = new DMatrixRMaj(5, 6);
+
+        for (int n = 0; n <= A.numRows; n++) {
+            B.set(A);
+            CommonOps_DDRM.shiftRowsDown(B, n);
+            for (int row = 0; row < n; row++) {
+                for (int col = 0; col < A.numCols; col++) {
+                    assertEquals(0.0, B.get(row, col), UtilEjml.TEST_F64);
+                }
+            }
+            for (int row = n; row < A.numRows; row++) {
+                for (int col = 0; col < A.numCols; col++) {
+                    assertEquals(A.get(row - n, col), B.get(row, col), UtilEjml.TEST_F64);
+                }
+            }
+        }
+    }
+
+    @Test
     public void addEquals() {
         DMatrixRMaj a = new DMatrixRMaj(2, 3, true, 0, 1, 2, 3, 4, 5);
         DMatrixRMaj b = new DMatrixRMaj(2, 3, true, 5, 4, 3, 2, 1, 0);


### PR DESCRIPTION
These row shifting functions were created for an experimental implementation of fixed lag smoother based on Kalman filter.
The shift functions were optimized out of that filter implementation later, but they may be useful for some other projects.