### PR TITLE
Fix simple matrix `getType` methods

### DIFF
--- a/main/ejml-core/src/org/ejml/EjmlUnitTests.java
+++ b/main/ejml-core/src/org/ejml/EjmlUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml;
 
 import org.ejml.data.*;
@@ -108,10 +107,14 @@ public class EjmlUnitTests {
     }
 
     public static void assertEquals( Matrix A, Matrix B ) {
-        if (A instanceof DMatrix) {
+        if (A instanceof DMatrix && B instanceof DMatrix) {
             assertEquals((DMatrix)A, (DMatrix)B, UtilEjml.TEST_F64);
-        } else {
+        } else if (A instanceof FMatrix && B instanceof FMatrix) {
             assertEquals((FMatrix)A, (FMatrix)B, UtilEjml.TEST_F32);
+        } else if (A instanceof FMatrix) {
+            assertEquals((FMatrix)A, (DMatrix)B, UtilEjml.TEST_F32);
+        } else {
+            assertEquals((FMatrix)B, (DMatrix)A, UtilEjml.TEST_F32);
         }
     }
 
@@ -230,6 +233,23 @@ public class EjmlUnitTests {
                 assertTrue(!Float.isInfinite(valA) && !Float.isInfinite(valB), "At (" + i + "," + j + ") A = " + valA + " B = " + valB);
 
                 float error = Math.abs(valA - valB);
+                assertTrue(error <= tol, "At (" + i + "," + j + ") A = " + valA + " B = " + valB + " error = " + error + " tol = " + tol);
+            }
+        }
+    }
+
+    private static void assertEquals( FMatrix A, DMatrix B, float tol ) {
+        assertShape(A, B);
+
+        for (int i = 0; i < A.getNumRows(); i++) {
+            for (int j = 0; j < A.getNumCols(); j++) {
+                float valA = A.get(i, j);
+                double valB = B.get(i, j);
+
+                assertTrue(!Float.isNaN(valA) && !Double.isNaN(valB), "At (" + i + "," + j + ") A = " + valA + " B = " + valB);
+                assertTrue(!Float.isInfinite(valA) && !Double.isInfinite(valB), "At (" + i + "," + j + ") A = " + valA + " B = " + valB);
+
+                var error = Math.abs(valA - valB);
                 assertTrue(error <= tol, "At (" + i + "," + j + ") A = " + valA + " B = " + valB + " error = " + error + " tol = " + tol);
             }
         }

--- a/main/ejml-core/src/org/ejml/ops/ConvertMatrixType.java
+++ b/main/ejml-core/src/org/ejml/ops/ConvertMatrixType.java
@@ -28,6 +28,7 @@ public class ConvertMatrixType {
     /**
      * Converts a matrix of one data type into another data type. If no conversion is known then an exception
      * is thrown.
+     * The result is always a new matrix instance, even if the matrix already has the desired type.
      *
      * @return The converted matrix
      */
@@ -35,13 +36,12 @@ public class ConvertMatrixType {
     public static Matrix convert( Matrix matrix, MatrixType desired ) {
         Matrix m = null;
 
-        if (matrix.getType().equals(desired)) {
-            return matrix;
-        }
-
         switch (matrix.getType()) {
             case DDRM: {
                 switch (desired) {
+                    case DDRM: {
+                        m = matrix.copy();
+                    } break;
                     case FDRM: {
                         m = new FMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((DMatrixRMaj)matrix, (FMatrixRMaj)m);
@@ -72,6 +72,9 @@ public class ConvertMatrixType {
 
             case FDRM: {
                 switch (desired) {
+                    case FDRM: {
+                        m = matrix.copy();
+                    } break;
                     case DDRM: {
                         m = new DMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((FMatrixRMaj)matrix, (DMatrixRMaj)m);
@@ -102,6 +105,9 @@ public class ConvertMatrixType {
 
             case ZDRM: {
                 switch (desired) {
+                    case ZDRM: {
+                        m = matrix.copy();
+                    } break;
                     case CDRM: {
                         m = new CMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((ZMatrixRMaj)matrix, (CMatrixRMaj)m);
@@ -112,6 +118,9 @@ public class ConvertMatrixType {
 
             case CDRM: {
                 switch (desired) {
+                    case CDRM: {
+                        m = matrix.copy();
+                    } break;
                     case ZDRM: {
                         m = new ZMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((CMatrixRMaj)matrix, (ZMatrixRMaj)m);
@@ -122,6 +131,9 @@ public class ConvertMatrixType {
 
             case DSCC: {
                 switch (desired) {
+                    case DSCC: {
+                        m = matrix.copy();
+                    } break;
                     case DDRM: {
                         m = new DMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         DConvertMatrixStruct.convert((DMatrixSparseCSC)matrix, (DMatrixRMaj)m);
@@ -152,6 +164,9 @@ public class ConvertMatrixType {
 
             case FSCC: {
                 switch (desired) {
+                    case FSCC: {
+                        m = matrix.copy();
+                    } break;
                     case DDRM: {
                         m = new DMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((FMatrixSparseCSC)matrix, (DMatrixRMaj)m);

--- a/main/ejml-core/src/org/ejml/ops/ConvertMatrixType.java
+++ b/main/ejml-core/src/org/ejml/ops/ConvertMatrixType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.data.*;
@@ -36,12 +35,13 @@ public class ConvertMatrixType {
     public static Matrix convert( Matrix matrix, MatrixType desired ) {
         Matrix m = null;
 
+        if (matrix.getType().equals(desired)) {
+            return matrix;
+        }
+
         switch (matrix.getType()) {
             case DDRM: {
                 switch (desired) {
-                    case DDRM: {
-                        m = matrix.copy();
-                    } break;
                     case FDRM: {
                         m = new FMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((DMatrixRMaj)matrix, (FMatrixRMaj)m);
@@ -72,9 +72,6 @@ public class ConvertMatrixType {
 
             case FDRM: {
                 switch (desired) {
-                    case FDRM: {
-                        m = matrix.copy();
-                    } break;
                     case DDRM: {
                         m = new DMatrixRMaj(matrix.getNumRows(), matrix.getNumCols());
                         ConvertMatrixData.convert((FMatrixRMaj)matrix, (DMatrixRMaj)m);

--- a/main/ejml-core/test/org/ejml/ops/TestConvertMatrixType.java
+++ b/main/ejml-core/test/org/ejml/ops/TestConvertMatrixType.java
@@ -42,9 +42,6 @@ public class TestConvertMatrixType {
             Matrix matA = a.create(4,6);
 
             for( MatrixType b : types ) {
-                if( a == b )
-                    continue;
-
                 // can't convert complex to real
                 if( !a.isReal() && b.isReal() )
                     continue;

--- a/main/ejml-core/test/org/ejml/ops/TestConvertMatrixType.java
+++ b/main/ejml-core/test/org/ejml/ops/TestConvertMatrixType.java
@@ -23,8 +23,7 @@ import org.ejml.data.MatrixType;
 import org.junit.jupiter.api.Test;
 
 import static org.ejml.data.MatrixType.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Peter Abeles
@@ -36,25 +35,22 @@ public class TestConvertMatrixType {
      */
     @Test
     public void basicCheckAll() {
-        MatrixType types[] = new MatrixType[]{DDRM,FDRM,ZDRM,CDRM,DSCC,FSCC};
+        MatrixType[] types = new MatrixType[]{DDRM,FDRM,ZDRM,CDRM,DSCC,FSCC};
 
-        for( MatrixType a : types ) {
-            Matrix matA = a.create(4,6);
+        for (MatrixType a : types) {
+            Matrix matA = a.create(4, 6);
 
-            for( MatrixType b : types ) {
+            for (MatrixType b : types) {
                 // can't convert complex to real
-                if( !a.isReal() && b.isReal() )
+                if (!a.isReal() && b.isReal())
                     continue;
 
-                Matrix matB = ConvertMatrixType.convert(matA,b);
+                Matrix matB = ConvertMatrixType.convert(matA, b);
 
-                if( matB == null ) {
-                    System.out.println(a+" -> "+b);
-                    fail("returned null");
-                }
-
-                assertEquals(matA.getNumRows(),matB.getNumRows());
-                assertEquals(matA.getNumCols(),matB.getNumCols());
+                assertNotNull(matB);
+                assertNotSame(matA, matB);
+                assertEquals(matA.getNumRows(), matB.getNumRows());
+                assertEquals(matA.getNumCols(), matB.getNumCols());
             }
         }
     }

--- a/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
@@ -95,27 +95,27 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     public DMatrixRMaj getDDRM() {
-        return (DMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.DDRM);
+        return (mat.getType() == MatrixType.DDRM) ? (DMatrixRMaj)mat : (DMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.DDRM);
     }
 
     public FMatrixRMaj getFDRM() {
-        return (FMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.FDRM);
+        return (mat.getType() == MatrixType.FDRM) ? (FMatrixRMaj)mat : (FMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.FDRM);
     }
 
     public ZMatrixRMaj getZDRM() {
-        return (ZMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.ZDRM);
+        return (mat.getType() == MatrixType.ZDRM) ? (ZMatrixRMaj)mat : (ZMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.ZDRM);
     }
 
     public CMatrixRMaj getCDRM() {
-        return (CMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.CDRM);
+        return (mat.getType() == MatrixType.CDRM) ? (CMatrixRMaj)mat : (CMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.CDRM);
     }
 
     public DMatrixSparseCSC getDSCC() {
-        return (DMatrixSparseCSC) ConvertMatrixType.convert(mat, MatrixType.DSCC);
+        return (mat.getType() == MatrixType.DSCC) ? (DMatrixSparseCSC)mat : (DMatrixSparseCSC)ConvertMatrixType.convert(mat, MatrixType.DSCC);
     }
 
     public FMatrixSparseCSC getFSCC() {
-        return (FMatrixSparseCSC) ConvertMatrixType.convert(mat, MatrixType.FSCC);
+        return (mat.getType() == MatrixType.FSCC) ? (FMatrixSparseCSC)mat : (FMatrixSparseCSC)ConvertMatrixType.convert(mat, MatrixType.FSCC);
     }
 
     protected static SimpleOperations lookupOps( MatrixType type ) {

--- a/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.UtilEjml;
@@ -23,6 +22,7 @@ import org.ejml.data.*;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.dense.row.NormOps_DDRM;
 import org.ejml.equation.Equation;
+import org.ejml.ops.ConvertMatrixType;
 import org.ejml.ops.DConvertMatrixStruct;
 import org.ejml.ops.FConvertMatrixStruct;
 import org.ejml.ops.MatrixIO;
@@ -95,27 +95,27 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     public DMatrixRMaj getDDRM() {
-        return (DMatrixRMaj)mat;
+        return (DMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.DDRM);
     }
 
     public FMatrixRMaj getFDRM() {
-        return (FMatrixRMaj)mat;
+        return (FMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.FDRM);
     }
 
     public ZMatrixRMaj getZDRM() {
-        return (ZMatrixRMaj)mat;
+        return (ZMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.ZDRM);
     }
 
     public CMatrixRMaj getCDRM() {
-        return (CMatrixRMaj)mat;
+        return (CMatrixRMaj) ConvertMatrixType.convert(mat, MatrixType.CDRM);
     }
 
     public DMatrixSparseCSC getDSCC() {
-        return (DMatrixSparseCSC)mat;
+        return (DMatrixSparseCSC) ConvertMatrixType.convert(mat, MatrixType.DSCC);
     }
 
     public FMatrixSparseCSC getFSCC() {
-        return (FMatrixSparseCSC)mat;
+        return (FMatrixSparseCSC) ConvertMatrixType.convert(mat, MatrixType.FSCC);
     }
 
     protected static SimpleOperations lookupOps( MatrixType type ) {

--- a/main/ejml-simple/test/org/ejml/simple/TestSimpleMatrix.java
+++ b/main/ejml-simple/test/org/ejml/simple/TestSimpleMatrix.java
@@ -129,6 +129,34 @@ public class TestSimpleMatrix {
     }
 
     @Test
+    public void convertToSparse() {
+        var data = new double[]{0, 1, 0, 1};
+        var simpleMatrix = new SimpleMatrix(2, 2, true, data);
+        assertTrue(simpleMatrix.getType().isDense());
+        var denseMatrix = simpleMatrix.mat.copy();
+
+        simpleMatrix.convertToSparse();
+
+        assertFalse(simpleMatrix.getType().isDense());
+        EjmlUnitTests.assertEquals(denseMatrix, simpleMatrix.mat);
+    }
+
+    @Test
+    public void transformMatrix() {
+        var data = new float[]{0, 1, 0, 1};
+        var s = new SimpleMatrix(2, 2, true, data);
+
+        var sparseDMatrix = s.getDSCC();
+        var sparseFMatrix = s.getFSCC();
+        var denseDMatrix = s.getDDRM();
+        var denseFMatrix = s.getFDRM();
+
+        EjmlUnitTests.assertEquals(sparseDMatrix, denseDMatrix);
+        EjmlUnitTests.assertEquals(sparseDMatrix, sparseFMatrix);
+        EjmlUnitTests.assertEquals(sparseDMatrix, denseFMatrix);
+    }
+
+    @Test
     public void transpose() {
         SimpleMatrix orig = SimpleMatrix.random_DDRM(3, 2, 0, 1, rand);
         SimpleMatrix tran = orig.transpose();


### PR DESCRIPTION
based on issue #139 

Now implicitly converting to the required type if needed.
Also added a matrix equals for combination of float and double matrices