### PR TITLE
feature/simple_concurrent

### DIFF
--- a/change.txt
+++ b/change.txt
@@ -11,20 +11,13 @@ Date format: year/month/day
   * Thanks CLOVIS-AI for pointing out the issue
 - Regression Testing
   * Added runtime regression using existing JMH benchmarks
-  * TODO baseline should be a copy not a renaming
-  * TODO change baseline when version is updated automatically. run, compare, then update
-  * TODO record the SHA it was compared against
-  * TODO record the tolerance for similarity and make command line configurable
 - Refactor set(obj) -> setTo(obj)
 - CommonOps
   * Fix a rather glaring bug in rref(). Thanks KayakDov
-- TODO identify sparse decompositions which can be made concurrent
-- TODO identify dense decompositions which require specialized algorithms for concurrency
+- SimpleMatrix
+  * Automatic type conversion. Thanks Florentin Dörre
+  * Automatic switching to concurrent algorithms when available
 
-Future
-- TODO Provide a mult_BL function that automatically converts to a block format and back, but modifies the input?
-- TODO Concurrency for Complex Matrices
-- TODO QR Decomposition. Make Block Householder computation more efficient. Single block?
 
 ----- Version 0.40
 2020/11/04

--- a/docs/feature_requests.txt
+++ b/docs/feature_requests.txt
@@ -1,3 +1,14 @@
+Future
+- TODO Provide a mult_BL function that automatically converts to a block format and back, but modifies the input?
+- TODO Concurrency for Complex Matrices
+- TODO QR Decomposition. Make Block Householder computation more efficient. Single block?
+
+TODO Regression
+  * TODO baseline should be a copy not a renaming
+  * TODO change baseline when version is updated automatically. run, compare, then update
+  * TODO record the SHA it was compared against
+  * TODO record the tolerance for similarity and make command line configurable
+
 TODO Sparse LDL
 TODO constructor size check
 TODO New implementation of symmetric eigen

--- a/main/ejml-core/src/org/ejml/concurrency/EjmlConcurrency.java
+++ b/main/ejml-core/src/org/ejml/concurrency/EjmlConcurrency.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.concurrency;
 
 import org.ejml.data.Matrix;

--- a/main/ejml-core/src/org/ejml/concurrency/EjmlConcurrency.java
+++ b/main/ejml-core/src/org/ejml/concurrency/EjmlConcurrency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -18,6 +18,8 @@
 
 package org.ejml.concurrency;
 
+import org.ejml.data.Matrix;
+import org.ejml.data.MatrixSparse;
 import pabeles.concurrency.ConcurrencyOps;
 
 /**
@@ -28,6 +30,9 @@ import pabeles.concurrency.ConcurrencyOps;
 public class EjmlConcurrency extends ConcurrencyOps {
 	/** Used to toggle auto matic switching to concurrent algorithms */
 	public static boolean USE_CONCURRENT = true;
+
+	/** Minimum number of elements in a matrix before it will switch to concurrent implementation */
+	public static int ELEMENT_THRESHOLD = 50_000;
 
 	/**
 	 * Sets the maximum number of threads available in the thread pool and adjusts USE_CONCURRENT. If
@@ -44,5 +49,27 @@ public class EjmlConcurrency extends ConcurrencyOps {
 
 	public static boolean isUseConcurrent() {
 		return USE_CONCURRENT;
+	}
+
+	/**
+	 * Returns true if the operation on the matrix should use the concurrent implementation. If the matrix
+	 * is too small it should always use a single threaded implementation since the overhead will slow it down.
+	 */
+	public static boolean useConcurrent( MatrixSparse mat ) {
+		if (!USE_CONCURRENT)
+			return false;
+
+		return mat.getNonZeroLength() > ELEMENT_THRESHOLD;
+	}
+
+	/**
+	 * Returns true if the operation on the matrix should use the concurrent implementation. If the matrix
+	 * is too small it should always use a single threaded implementation since the overhead will slow it down.
+	 */
+	public static boolean useConcurrent( Matrix mat ) {
+		if (!USE_CONCURRENT)
+			return false;
+
+		return mat.getNumRows()*mat.getNumCols() > ELEMENT_THRESHOLD;
 	}
 }

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DDRM.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DDRM.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple.ops;
 
 import org.ejml.concurrency.EjmlConcurrency;

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DDRM.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -18,10 +18,12 @@
 
 package org.ejml.simple.ops;
 
+import org.ejml.concurrency.EjmlConcurrency;
 import org.ejml.data.Complex_F64;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.data.Matrix;
 import org.ejml.dense.row.CommonOps_DDRM;
+import org.ejml.dense.row.CommonOps_MT_DDRM;
 import org.ejml.dense.row.MatrixFeatures_DDRM;
 import org.ejml.dense.row.NormOps_DDRM;
 import org.ejml.dense.row.mult.VectorVectorMult_DDRM;
@@ -68,17 +70,29 @@ public class SimpleOperations_DDRM implements SimpleOperations<DMatrixRMaj> {
 
     @Override
     public void transpose( DMatrixRMaj input, DMatrixRMaj output ) {
-        CommonOps_DDRM.transpose(input, output);
+        if (EjmlConcurrency.useConcurrent(input)) {
+            CommonOps_MT_DDRM.transpose(input, output);
+        } else {
+            CommonOps_DDRM.transpose(input, output);
+        }
     }
 
     @Override
     public void mult( DMatrixRMaj A, DMatrixRMaj B, DMatrixRMaj output ) {
-        CommonOps_DDRM.mult(A, B, output);
+        if (EjmlConcurrency.useConcurrent(A)) {
+            CommonOps_MT_DDRM.mult(A, B, output);
+        } else {
+            CommonOps_DDRM.mult(A, B, output);
+        }
     }
 
     @Override
     public void multTransA( DMatrixRMaj A, DMatrixRMaj B, DMatrixRMaj output ) {
-        CommonOps_DDRM.multTransA(A, B, output);
+        if (EjmlConcurrency.useConcurrent(A)) {
+            CommonOps_MT_DDRM.multTransA(A, B, output);
+        } else {
+            CommonOps_DDRM.multTransA(A, B, output);
+        }
     }
 
     @Override

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
@@ -154,7 +154,7 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
 
     @Override
     public void plus( DMatrixSparseCSC A, /**/double beta, DMatrixSparseCSC b, DMatrixSparseCSC output ) {
-        if (EjmlConcurrency.USE_CONCURRENT) {
+        if (EjmlConcurrency.useConcurrent(A)) {
             CommonOps_MT_DSCC.add(1, A, (double)beta, b, output, workspaceMT);
         } else {
             CommonOps_DSCC.add(1, A, (double)beta, b, output, gw, gx);
@@ -163,7 +163,7 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
 
     @Override
     public void plus( /**/double alpha, DMatrixSparseCSC A, /**/double beta, DMatrixSparseCSC b, DMatrixSparseCSC output ) {
-        if (EjmlConcurrency.USE_CONCURRENT) {
+        if (EjmlConcurrency.useConcurrent(A)) {
             CommonOps_MT_DSCC.add((double)alpha, A, (double)beta, b, output, workspaceMT);
         } else {
             CommonOps_DSCC.add((double)alpha, A, (double)beta, b, output, gw, gx);

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -18,14 +18,18 @@
 
 package org.ejml.simple.ops;
 
+import org.ejml.concurrency.EjmlConcurrency;
 import org.ejml.data.*;
 import org.ejml.ops.MatrixIO;
 import org.ejml.simple.ConvertToDenseException;
 import org.ejml.simple.ConvertToImaginaryException;
 import org.ejml.simple.SimpleSparseOperations;
 import org.ejml.sparse.csc.CommonOps_DSCC;
+import org.ejml.sparse.csc.CommonOps_MT_DSCC;
 import org.ejml.sparse.csc.MatrixFeatures_DSCC;
 import org.ejml.sparse.csc.NormOps_DSCC;
+import org.ejml.sparse.csc.mult.Workspace_MT_DSCC;
+import pabeles.concurrency.GrowArray;
 
 import java.io.PrintStream;
 
@@ -39,6 +43,10 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
     // Workspace variables
     public transient IGrowArray gw = new IGrowArray();
     public transient DGrowArray gx = new DGrowArray();
+
+    // Workspace for concurrent algorithms
+    public transient GrowArray<Workspace_MT_DSCC> workspaceMT = new GrowArray<>(Workspace_MT_DSCC::new);
+    public transient GrowArray<DGrowArray> workspaceA = new GrowArray<>(DGrowArray::new);
 
     @Override
     public void set( DMatrixSparseCSC A, int row, int column, /**/double value ) {
@@ -77,14 +85,23 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
 
     @Override
     public void mult( DMatrixSparseCSC A, DMatrixSparseCSC B, DMatrixSparseCSC output ) {
-        CommonOps_DSCC.mult(A, B, output);
+        if (EjmlConcurrency.useConcurrent(A)) {
+            CommonOps_MT_DSCC.mult(A, B, output, workspaceMT);
+        } else {
+            CommonOps_DSCC.mult(A, B, output);
+        }
     }
 
     @Override
     public void multTransA( DMatrixSparseCSC A, DMatrixSparseCSC B, DMatrixSparseCSC output ) {
         var At = new DMatrixSparseCSC(1, 1);
         CommonOps_DSCC.transpose(A, At, gw);
-        CommonOps_DSCC.mult(At, B, output, gw, gx);
+
+        if (EjmlConcurrency.useConcurrent(A)) {
+            CommonOps_MT_DSCC.mult(A, B, output, workspaceMT);
+        } else {
+            CommonOps_DSCC.mult(At, B, output, gw, gx);
+        }
     }
 
     @Override
@@ -94,18 +111,26 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
 
     @Override
     public void multTransA( DMatrixSparseCSC A, DMatrixRMaj B, DMatrixRMaj output ) {
-        CommonOps_DSCC.multTransA(A, B, output, null);
+        if (EjmlConcurrency.useConcurrent(A)) {
+            CommonOps_MT_DSCC.multTransA(A, B, output, workspaceA);
+        } else {
+            CommonOps_DSCC.multTransA(A, B, output, null);
+        }
     }
 
     @Override
     public void mult( DMatrixSparseCSC A, DMatrixRMaj B, DMatrixRMaj output ) {
-        CommonOps_DSCC.mult(A, B, output);
+        if (EjmlConcurrency.useConcurrent(A)) {
+            CommonOps_MT_DSCC.mult(A, B, output, workspaceA);
+        } else {
+            CommonOps_DSCC.mult(A, B, output);
+        }
     }
 
     @Override
     public void kron( DMatrixSparseCSC A, DMatrixSparseCSC B, DMatrixSparseCSC output ) {
 //        CommonOps_DSCC.kron(A,B,output);
-        throw new RuntimeException("Unsupported");
+        throw new RuntimeException("Unsupported. Make a feature request if you need this!");
     }
 
     @Override
@@ -130,12 +155,20 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
 
     @Override
     public void plus( DMatrixSparseCSC A, /**/double beta, DMatrixSparseCSC b, DMatrixSparseCSC output ) {
-        CommonOps_DSCC.add(1, A, (double)beta, b, output, gw, gx);
+        if (EjmlConcurrency.USE_CONCURRENT) {
+            CommonOps_MT_DSCC.add(1, A, (double)beta, b, output, workspaceMT);
+        } else {
+            CommonOps_DSCC.add(1, A, (double)beta, b, output, gw, gx);
+        }
     }
 
     @Override
     public void plus( /**/double alpha, DMatrixSparseCSC A, /**/double beta, DMatrixSparseCSC b, DMatrixSparseCSC output ) {
-        CommonOps_DSCC.add((double)alpha, A, (double)beta, b, output, gw, gx);
+        if (EjmlConcurrency.USE_CONCURRENT) {
+            CommonOps_MT_DSCC.add((double)alpha, A, (double)beta, b, output, workspaceMT);
+        } else {
+            CommonOps_DSCC.add((double)alpha, A, (double)beta, b, output, gw, gx);
+        }
     }
 
     @Override

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple.ops;
 
 import org.ejml.concurrency.EjmlConcurrency;


### PR DESCRIPTION
- Operations for simple matrix will now switch to concurrent implementation when available

Thank you for your contribution to the EJML project.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please make sure:
- [ ] Your code is covered by tests
- [x] You ran `./gradlew spotlessJavaApply`