### PR TITLE
Update set method for sparse to only add non-zero elements

### DIFF
--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseCSC.java
@@ -231,7 +231,9 @@ public class DMatrixSparseCSC implements DMatrixSparse {
         if (row < 0 || row >= numRows || col < 0 || col >= numCols)
             throw new IllegalArgumentException("Outside of matrix bounds");
 
-        unsafe_set(row, col, val);
+        if (val != 0.0) {
+            unsafe_set(row, col, val);
+        }
     }
 
     @Override

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -154,8 +154,8 @@ public class DMatrixSparseTriplet implements DMatrixSparse {
         if (row < 0 || row >= numRows || col < 0 || col >= numCols)
             throw new IllegalArgumentException("Outside of matrix bounds");
 
-        if (val != 0.0) {
-            unsafe_set(row, col, val);
+        if (value != 0.0) {
+            unsafe_set(row, col, value);
         }
     }
 

--- a/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixSparseTriplet.java
@@ -154,7 +154,9 @@ public class DMatrixSparseTriplet implements DMatrixSparse {
         if (row < 0 || row >= numRows || col < 0 || col >= numCols)
             throw new IllegalArgumentException("Outside of matrix bounds");
 
-        unsafe_set(row, col, value);
+        if (val != 0.0) {
+            unsafe_set(row, col, val);
+        }
     }
 
     /**
@@ -169,7 +171,7 @@ public class DMatrixSparseTriplet implements DMatrixSparse {
         int index = nz_index(row, col);
         if (index < 0)
             addItem(row, col, value);
-        else {
+        else if (value != 0.0) {
             nz_value.data[index] = value;
         }
     }


### PR DESCRIPTION
I think it makes sense to disregard irrelevant values for the sparse matrices. I first noticed this issue when using another library (`kmath`) which has a `buildMatrix` method they yet have to specialize for sparse structures. 
This `buildMatrix` would be much better off if the `set` method never applied "0" elements. They risk of doubling the array-size way larger than required would still exist, but at least we wouldn't make sure that it happens 😉 

The best approach forward is for `kmath` to better support sparse structures, but this step in the right direction would be helpful for not only `kmath`-user but also `ejml` ones 😄 


Before submitting this PR, please make sure:
- [-] Your code is covered by tests (something about memory breaking, not sure what...)
- [X] You ran `./gradlew spotlessJavaApply`