### PR TITLE
Fix #147 and add QOL changes to some Simple classes

### DIFF
--- a/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
@@ -790,6 +790,20 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     /**
+     * Returns 2D array of doubles using the {@link SimpleBase#get(int, int)} method.
+     * @return 2D array of doubles.
+     */
+    public double[][] toArray2() {
+        double[][] array = new double[mat.getNumRows()][mat.getNumCols()];
+        for (int r = 0; r < mat.getNumRows(); r++) {
+            for (int c = 0; c < mat.getNumCols(); c++) {
+                array[r][c] = get(r, c);
+            }
+        }
+        return array;
+    }
+
+    /**
      * <p>
      * Converts the array into a string format for display purposes.
      * The conversion is done using {@link MatrixIO#print(java.io.PrintStream, DMatrix)}.
@@ -999,6 +1013,24 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
         ret.insertIntoThis(insertRow, insertCol, B);
 
         return ret;
+    }
+
+    /**
+     * Returns the maximum real value of all the elements in this matrix.
+     *
+     * @return Largest real value of any element.
+     */
+    public double elementMax() {
+        return ops.elementMax(mat);
+    }
+
+    /**
+     * Returns the minimum real value of all the elements in this matrix.
+     *
+     * @return Smallest real value of any element.
+     */
+    public double elementMin() {
+        return ops.elementMin(mat);
     }
 
     /**

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.data.*;
@@ -141,6 +140,18 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
+     * Creates a column vector with the values and shape defined by the 1D array 'data'.
+     * @param data 1D array representation of the vector. Not modified.
+     */
+    public SimpleMatrix( double data[] ) {
+        setMatrix(new DMatrixRMaj(data.length, 1, true, data));
+    }
+
+    public SimpleMatrix( float data[] ) {
+        setMatrix(new FMatrixRMaj(data.length, 1, true, data));
+    }
+
+    /**
      * Creates a new matrix that is initially set to zero with the specified dimensions. This will wrap a
      * {@link DMatrixRMaj}.
      *
@@ -232,6 +243,29 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
         SimpleMatrix ret = new SimpleMatrix();
         ret.setMatrix(internalMat);
         return ret;
+    }
+
+    /**
+     * Returns a filled matrix (numRows x numCols) of the value a.
+     * @param numRows The number of numRows.
+     * @param numCols The number of columns.
+     * @param a The number to fill the matrix with.
+     * @return A matrix filled with the value a.
+     */
+    public static SimpleMatrix filled( int numRows, int numCols, double a ) {
+        SimpleMatrix res = new SimpleMatrix(numRows, numCols);
+        res.fill(a);
+        return res;
+    }
+
+    /**
+     * Returns a matrix of ones.
+     * @param numRows The number of numRows.
+     * @param numCols The number of columns.
+     * @return A matrix of ones.
+     */
+    public static SimpleMatrix ones( int numRows, int numCols ) {
+        return filled(numRows, numCols, 1);
     }
 
     /**

--- a/main/ejml-simple/src/org/ejml/simple/SimpleOperations.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.data.Complex_F64;
@@ -100,6 +99,10 @@ public interface SimpleOperations<T extends Matrix> extends Serializable {
     boolean hasUncountable( T M );
 
     void changeSign( T a );
+
+    double elementMax( T A );
+
+    double elementMin( T A );
 
     double elementMaxAbs( T A );
 

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DDRM.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DDRM.java
@@ -234,6 +234,16 @@ public class SimpleOperations_DDRM implements SimpleOperations<DMatrixRMaj> {
     }
 
     @Override
+    public /**/double elementMax( DMatrixRMaj A ) {
+        return CommonOps_DDRM.elementMax(A);
+    }
+
+    @Override
+    public /**/double elementMin( DMatrixRMaj A ) {
+        return CommonOps_DDRM.elementMin(A);
+    }
+
+    @Override
     public /**/double elementMaxAbs( DMatrixRMaj A ) {
         return CommonOps_DDRM.elementMaxAbs(A);
     }

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_DSCC.java
@@ -291,6 +291,16 @@ public class SimpleOperations_DSCC implements SimpleSparseOperations<DMatrixSpar
     }
 
     @Override
+    public /**/double elementMax( DMatrixSparseCSC A ) {
+        return CommonOps_DSCC.elementMax(A);
+    }
+
+    @Override
+    public /**/double elementMin( DMatrixSparseCSC A ) {
+        return CommonOps_DSCC.elementMin(A);
+    }
+
+    @Override
     public /**/double elementMaxAbs( DMatrixSparseCSC A ) {
         return CommonOps_DSCC.elementMaxAbs(A);
     }

--- a/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_ZDRM.java
+++ b/main/ejml-simple/src/org/ejml/simple/ops/SimpleOperations_ZDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2021, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple.ops;
 
 import org.ejml.data.Complex_F64;
@@ -227,6 +226,16 @@ public class SimpleOperations_ZDRM implements SimpleOperations<ZMatrixRMaj> {
     public void changeSign( ZMatrixRMaj a ) {
 //        CommonOps_ZDRM.changeSign(a);
         throw new UnsupportedOperation();
+    }
+
+    @Override
+    public /**/double elementMax( ZMatrixRMaj A ) {
+        return CommonOps_ZDRM.elementMaxReal(A);
+    }
+
+    @Override
+    public /**/double elementMin( ZMatrixRMaj A ) {
+        return CommonOps_ZDRM.elementMinReal(A);
     }
 
     @Override

--- a/main/ejml-simple/test/org/ejml/simple/TestSimpleMatrix.java
+++ b/main/ejml-simple/test/org/ejml/simple/TestSimpleMatrix.java
@@ -69,6 +69,15 @@ public class TestSimpleMatrix extends EjmlStandardJUnit {
     }
 
     @Test
+    public void constructor_1d_array_simple() {
+        double[] d = new double[]{2, 5, 3, 9, -2, 6, 7, 4};
+        SimpleMatrix s = new SimpleMatrix(d);
+        DMatrixRMaj m = new DMatrixRMaj(8, 1, true, d);
+
+        EjmlUnitTests.assertEquals((DMatrixRMaj)m, (DMatrixRMaj)s.getMatrix(), UtilEjml.TEST_F64);
+    }
+
+    @Test
     public void constructor_2d_array() {
         double[][] d = new double[][]{{1, 2}, {3, 4}, {5, 6}};
 
@@ -110,6 +119,26 @@ public class TestSimpleMatrix extends EjmlStandardJUnit {
         SimpleMatrix s = SimpleMatrix.identity(3);
 
         DMatrixRMaj d = CommonOps_DDRM.identity(3);
+
+        EjmlUnitTests.assertEquals(d, (DMatrixRMaj)s.mat, UtilEjml.TEST_F64);
+    }
+
+    @Test
+    public void ones() {
+        SimpleMatrix s = SimpleMatrix.ones(3, 3);
+
+        DMatrixRMaj d = new DMatrixRMaj(3, 3);
+        d.fill(1);
+
+        EjmlUnitTests.assertEquals(d, (DMatrixRMaj)s.mat, UtilEjml.TEST_F64);
+    }
+
+    @Test
+    public void filled() {
+        SimpleMatrix s = SimpleMatrix.filled(3, 3, 2);
+
+        DMatrixRMaj d = new DMatrixRMaj(3, 3);
+        d.fill(2);
 
         EjmlUnitTests.assertEquals(d, (DMatrixRMaj)s.mat, UtilEjml.TEST_F64);
     }
@@ -497,6 +526,21 @@ public class TestSimpleMatrix extends EjmlStandardJUnit {
     }
 
     @Test
+    public void toArray2() {
+        SimpleMatrix a = SimpleMatrix.random_DDRM(3, 2, 0, 1, rand);
+
+        double[][] array2 = a.toArray2();
+        assertEquals(a.numRows(), array2.length);
+        assertEquals(a.numCols(), array2[0].length);
+
+        for (int i = 0; i < array2.length; i++) {
+            for (int j = 0; j < array2[0].length; j++) {
+                assertEquals(array2[i][j], a.get(i, j), 0);
+            }
+        }
+    }
+
+    @Test
     public void copy() {
         SimpleMatrix a = SimpleMatrix.random_DDRM(3, 3, 0, 1, rand);
         SimpleMatrix b = a.copy();
@@ -614,6 +658,26 @@ public class TestSimpleMatrix extends EjmlStandardJUnit {
         }
 
         assertEquals(expectedSum, a.elementSum(), UtilEjml.TEST_F64);
+    }
+
+    @Test
+    public void elementMax() {
+        SimpleMatrix a = SimpleMatrix.random_DDRM(7, 5, 0, 1, rand);
+
+        a.set(3, 4, -5);
+        a.set(4, 4, 4);
+
+        assertEquals(4, a.elementMax(), 0.0);
+    }
+
+    @Test
+    public void elementMin() {
+        SimpleMatrix a = SimpleMatrix.random_DDRM(7, 5, 4, 10, rand);
+
+        a.set(3, 4, -2);
+        a.set(4, 4, 0.5);
+
+        assertEquals(-2, a.elementMin(), 0.0);
     }
 
     @Test


### PR DESCRIPTION
The first commit created 3 new files for some reason, although they were just changed by me. The only ambitious change in this PR is probably the column vector constructors, which take in one double/float[] and assume the client wants a [].length by 1 column vector.