### PR TITLE
Fix docstrings for SimpleBase and SimpleMatrix

### DIFF
--- a/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
@@ -329,7 +329,7 @@ public class DMatrixRMaj extends DMatrix1Row {
     }
 
     /**
-     * Creates and returns a matrix which is idential to this one.
+     * Creates and returns a matrix which is identical to this one.
      *
      * @return A new identical matrix.
      */

--- a/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CommonOps_DDRM.java
@@ -2679,7 +2679,7 @@ public class CommonOps_DDRM {
     }
 
     /**
-     * <p>Concatinates all the matrices together along their columns. If the rows do not match the upper elements
+     * <p>Concatenates all the matrices together along their columns. If the rows do not match the upper elements
      * are set to zero.</p>
      *
      * A = [ m[0] , ... , m[n-1] ]
@@ -2721,7 +2721,7 @@ public class CommonOps_DDRM {
     }
 
     /**
-     * <p>Concatinates all the matrices together along their columns. If the rows do not match the upper elements
+     * <p>Concatenates all the matrices together along their columns. If the rows do not match the upper elements
      * are set to zero.</p>
      *
      * A = [ m[0] ; ... ; m[n-1] ]

--- a/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
@@ -598,7 +598,7 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     /**
-     * Assigns an element a value based on its index in the internal array..
+     * Assigns an element a value based on its index in the internal array.
      *
      * @param index The matrix element that is being assigned a value.
      * @param value The element's new value.
@@ -734,7 +734,7 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     /**
-     * Creates and returns a matrix which is idential to this one.
+     * Creates and returns a matrix which is identical to this one.
      *
      * @return A new identical matrix.
      */
@@ -1035,7 +1035,7 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
 
     /**
      * Returns the maximum absolute value of all the elements in this matrix. This is
-     * equivalent the the infinite p-norm of the matrix.
+     * equivalent to the infinite p-norm of the matrix.
      *
      * @return Largest absolute value of any element.
      */
@@ -1339,7 +1339,7 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     /**
-     * <p>Concatinates all the matrices together along their columns. If the rows do not match the upper elements
+     * <p>Concatenates all the matrices together along their columns. If the rows do not match the upper elements
      * are set to zero.</p>
      *
      * A = [ this, m[0] , ... , m[n-1] ]
@@ -1374,7 +1374,7 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     /**
-     * <p>Concatinates all the matrices together along their columns. If the rows do not match the upper elements
+     * <p>Concatenates all the matrices together along their columns. If the rows do not match the upper elements
      * are set to zero.</p>
      *
      * A = [ this; m[0] ; ... ; m[n-1] ]
@@ -1411,8 +1411,8 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     /**
      * Extracts the specified rows from the matrix.
      *
-     * @param begin First row. Inclusive.
-     * @param end Last row + 1.
+     * @param begin First row (inclusive).
+     * @param end Last row (exclusive).
      * @return Submatrix that contains the specified rows.
      */
     public T rows( int begin, int end ) {
@@ -1420,18 +1420,18 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements Serializabl
     }
 
     /**
-     * Extracts the specified rows from the matrix.
+     * Extracts the specified columns from the matrix.
      *
-     * @param begin First row. Inclusive.
-     * @param end Last row + 1.
-     * @return Submatrix that contains the specified rows.
+     * @param begin First column (inclusive).
+     * @param end Last column (exclusive).
+     * @return Submatrix that contains the specified columns.
      */
     public T cols( int begin, int end ) {
         return extractMatrix(0, SimpleMatrix.END, begin, end);
     }
 
     /**
-     * Returns the type of matrix is is wrapping.
+     * Returns the type of matrix it is wrapping.
      */
     public MatrixType getType() {
         return mat.getType();

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -97,15 +97,6 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
      * column-major.
      * </p>
      *
-     * <p>
-     * Note that 'data' is a variable argument type, so either 1D arrays or a set of numbers can be
-     * passed in:<br>
-     * SimpleMatrix a = new SimpleMatrix(2,2,true,new double[]{1,2,3,4});<br>
-     * SimpleMatrix b = new SimpleMatrix(2,2,true,1,2,3,4);<br>
-     * <br>
-     * Both are equivalent.
-     * </p>
-     *
      * @param numRows The number of rows.
      * @param numCols The number of columns.
      * @param rowMajor If the array is encoded in a row-major or a column-major format.
@@ -116,6 +107,19 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
         setMatrix(new DMatrixRMaj(numRows, numCols, rowMajor, data));
     }
 
+    /**
+     * <p>
+     * Creates a new matrix which has the same value as the matrix encoded in the
+     * provided array. The input matrix's format can either be row-major or
+     * column-major.
+     * </p>
+     *
+     * @param numRows The number of rows.
+     * @param numCols The number of columns.
+     * @param rowMajor If the array is encoded in a row-major or a column-major format.
+     * @param data The formatted 1D array. Not modified.
+     * @see FMatrixRMaj#FMatrixRMaj(int, int, boolean, float...)
+     */
     public SimpleMatrix( int numRows, int numCols, boolean rowMajor, float[] data ) {
         setMatrix(new FMatrixRMaj(numRows, numCols, rowMajor, data));
     }
@@ -135,18 +139,35 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
         setMatrix(new DMatrixRMaj(data));
     }
 
+    /**
+     * <p>
+     * Creates a matrix with the values and shape defined by the 2D array 'data'.
+     * It is assumed that 'data' has a row-major formatting:<br>
+     * <br>
+     * data[ row ][ column ]
+     * </p>
+     *
+     * @param data 2D array representation of the matrix. Not modified.
+     * @see FMatrixRMaj#FMatrixRMaj(float[][])
+     */
     public SimpleMatrix( float data[][] ) {
         setMatrix(new FMatrixRMaj(data));
     }
 
     /**
      * Creates a column vector with the values and shape defined by the 1D array 'data'.
+     *
      * @param data 1D array representation of the vector. Not modified.
      */
     public SimpleMatrix( double data[] ) {
         setMatrix(new DMatrixRMaj(data.length, 1, true, data));
     }
 
+    /**
+     * Creates a column vector with the values and shape defined by the 1D array 'data'.
+     *
+     * @param data 1D array representation of the vector. Not modified.
+     */
     public SimpleMatrix( float data[] ) {
         setMatrix(new FMatrixRMaj(data.length, 1, true, data));
     }
@@ -199,7 +220,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creats a new SimpleMatrix which is identical to the original.
+     * Creates a new SimpleMatrix which is identical to the original.
      *
      * @param orig The matrix which is to be copied. Not modified.
      */

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -97,13 +97,22 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
      * column-major.
      * </p>
      *
+     * <p>
+     * Note that 'data' is a variable argument type, so either 1D arrays or a set of numbers can be
+     * passed in:<br>
+     * SimpleMatrix a = new SimpleMatrix(2,2,true,new double[]{1,2,3,4});<br>
+     * SimpleMatrix b = new SimpleMatrix(2,2,true,1,2,3,4);<br>
+     * <br>
+     * Both are equivalent.
+     * </p>
+     *
      * @param numRows The number of rows.
      * @param numCols The number of columns.
      * @param rowMajor If the array is encoded in a row-major or a column-major format.
      * @param data The formatted 1D array. Not modified.
      * @see DMatrixRMaj#DMatrixRMaj(int, int, boolean, double...)
      */
-    public SimpleMatrix( int numRows, int numCols, boolean rowMajor, double[] data ) {
+    public SimpleMatrix( int numRows, int numCols, boolean rowMajor, double... data ) {
         setMatrix(new DMatrixRMaj(numRows, numCols, rowMajor, data));
     }
 
@@ -114,13 +123,22 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
      * column-major.
      * </p>
      *
+     * <p>
+     * Note that 'data' is a variable argument type, so either 1D arrays or a set of numbers can be
+     * passed in:<br>
+     * SimpleMatrix a = new SimpleMatrix(2,2,true,new float[]{1,2,3,4});<br>
+     * SimpleMatrix b = new SimpleMatrix(2,2,true,1,2,3,4);<br>
+     * <br>
+     * Both are equivalent.
+     * </p>
+     *
      * @param numRows The number of rows.
      * @param numCols The number of columns.
      * @param rowMajor If the array is encoded in a row-major or a column-major format.
      * @param data The formatted 1D array. Not modified.
      * @see FMatrixRMaj#FMatrixRMaj(int, int, boolean, float...)
      */
-    public SimpleMatrix( int numRows, int numCols, boolean rowMajor, float[] data ) {
+    public SimpleMatrix( int numRows, int numCols, boolean rowMajor, float... data ) {
         setMatrix(new FMatrixRMaj(numRows, numCols, rowMajor, data));
     }
 


### PR DESCRIPTION
Various minor docstring fixes for `SimpleBase` and `SimpleMatrix`:
- fixed `SimpleBase#cols` to refer to columns rather than rows
- deleted paragraph referring to variable arguments which are not actually variable
- added missing docstrings for `SimpleMatrix` float constructors
- corrected a few typos