### PR TITLE
Fix SimpleMatrix type conversion

### DIFF
--- a/main/ejml-simple/src/org/ejml/simple/AutomaticSimpleMatrixConvert.java
+++ b/main/ejml-simple/src/org/ejml/simple/AutomaticSimpleMatrixConvert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2022, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.simple;
 
 import org.ejml.data.Matrix;
@@ -35,7 +34,7 @@ public class AutomaticSimpleMatrixConvert {
         SimpleBase array[] = new SimpleBase[inputs.length+1];
         System.arraycopy(inputs,0,array,0,inputs.length);
         array[inputs.length] = a;
-        specify(inputs);
+        specify(array);
     }
 
     public void specify( SimpleBase ...inputs ) {

--- a/main/ejml-simple/test/org/ejml/simple/TestSimpleMatrixConvertType.java
+++ b/main/ejml-simple/test/org/ejml/simple/TestSimpleMatrixConvertType.java
@@ -164,9 +164,11 @@ public class TestSimpleMatrixConvertType extends EjmlStandardJUnit {
         SimpleMatrix B = SimpleMatrix.wrap(RandomMatrices_DDRM.rectangle(6,2,rand));
 
         SimpleMatrix C = A.combine(0,1,B);
+        SimpleMatrix D = B.combine(0,1,A);
         assertEquals(MatrixType.FDRM,A.getType());
         assertEquals(MatrixType.DDRM,B.getType());
         assertEquals(MatrixType.DDRM,C.getType());
+        assertEquals(MatrixType.DDRM,D.getType());
     }
 
     @Test
@@ -175,9 +177,11 @@ public class TestSimpleMatrixConvertType extends EjmlStandardJUnit {
         SimpleMatrix B = SimpleMatrix.wrap(RandomMatrices_DDRM.rectangle(6,5,rand));
 
         SimpleMatrix C = A.elementMult(B);
+        SimpleMatrix D = B.elementMult(A);
         assertEquals(MatrixType.FDRM,A.getType());
         assertEquals(MatrixType.DDRM,B.getType());
         assertEquals(MatrixType.DDRM,C.getType());
+        assertEquals(MatrixType.DDRM,D.getType());
     }
 
     @Test
@@ -186,9 +190,11 @@ public class TestSimpleMatrixConvertType extends EjmlStandardJUnit {
         SimpleMatrix B = SimpleMatrix.wrap(RandomMatrices_DDRM.rectangle(6,5,rand));
 
         SimpleMatrix C = A.elementDiv(B);
+        SimpleMatrix D = B.elementDiv(A);
         assertEquals(MatrixType.FDRM,A.getType());
         assertEquals(MatrixType.DDRM,B.getType());
         assertEquals(MatrixType.DDRM,C.getType());
+        assertEquals(MatrixType.DDRM,D.getType());
     }
 
     @Test
@@ -197,9 +203,11 @@ public class TestSimpleMatrixConvertType extends EjmlStandardJUnit {
         SimpleMatrix B = SimpleMatrix.wrap(RandomMatrices_DDRM.rectangle(6,5,rand));
 
         SimpleMatrix C = A.elementPower(B);
+        SimpleMatrix D = B.elementPower(A);
         assertEquals(MatrixType.FDRM,A.getType());
         assertEquals(MatrixType.DDRM,B.getType());
         assertEquals(MatrixType.DDRM,C.getType());
+        assertEquals(MatrixType.DDRM,D.getType());
     }
 
     @Test
@@ -208,9 +216,11 @@ public class TestSimpleMatrixConvertType extends EjmlStandardJUnit {
         SimpleMatrix B = SimpleMatrix.wrap(RandomMatrices_DDRM.rectangle(6,5,rand));
 
         SimpleMatrix C = A.concatRows(B);
+        SimpleMatrix D = B.concatRows(A);
         assertEquals(MatrixType.FDRM,A.getType());
         assertEquals(MatrixType.DDRM,B.getType());
         assertEquals(MatrixType.DDRM,C.getType());
+        assertEquals(MatrixType.DDRM,D.getType());
     }
 
     @Test
@@ -219,9 +229,11 @@ public class TestSimpleMatrixConvertType extends EjmlStandardJUnit {
         SimpleMatrix B = SimpleMatrix.wrap(RandomMatrices_DDRM.rectangle(6,5,rand));
 
         SimpleMatrix C = A.concatColumns(B);
+        SimpleMatrix D = B.concatColumns(A);
         assertEquals(MatrixType.FDRM,A.getType());
         assertEquals(MatrixType.DDRM,B.getType());
         assertEquals(MatrixType.DDRM,C.getType());
+        assertEquals(MatrixType.DDRM,D.getType());
     }
 
 }


### PR DESCRIPTION
Fixes #156.

I added a some extra assertions to existing tests - the extra assertions for `concatRows` and `concatColumns` fail without the fix.