### PR TITLE
Add innerProduct for sparse vectors.

### DIFF
--- a/main/ejml-ddense/src/org/ejml/dense/row/mult/MatrixVectorMult_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/mult/MatrixVectorMult_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,14 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.mult;
 
+import java.util.Iterator;
+
 import org.ejml.MatrixDimensionException;
+import org.ejml.UtilEjml;
 import org.ejml.data.DMatrix1Row;
 import org.ejml.data.DMatrixD1;
 import org.ejml.data.DMatrixRMaj;
+import org.ejml.data.DMatrixSparse;
+import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.dense.row.CommonOps_DDRM;
+import org.ejml.dense.row.MatrixFeatures_DDRM;
 
 /**
  * <p>
@@ -345,5 +350,139 @@ public class MatrixVectorMult_DDRM {
         }
 
         return output;
+    }
+
+    /**
+     * scalar = A<sup>T</sup>*B*C
+     *
+     * @param A (Input) A vector that has length m.
+     * @param B (Input) A matrix that is m by n.
+     * @param C (Input)  A vector that has length n.
+     */
+    public static double innerProduct(DMatrixSparse A, DMatrix1Row B, DMatrixSparse C) {
+        checkInnerProductArguments(A, B, C);
+
+        VectorEntry[] nzValuesC = nzValues(C);
+        int sizeC = nzValuesC.length;
+
+        double output = 0.0;
+        for (Iterator<DMatrixSparse.CoordinateRealValue> i = A.createCoordinateIterator(); i.hasNext(); ) {
+            DMatrixSparse.CoordinateRealValue c1 = i.next();
+            double sum = 0.0;
+            for (int j=0; j<sizeC; j++) {
+                VectorEntry e2 = nzValuesC[j];
+                sum += e2.value * B.unsafe_get(c1.row, e2.index);
+            }
+            output += c1.value * sum;
+        }
+        return output;
+    }
+
+    private static void checkInnerProductArguments(DMatrixSparse A, DMatrix1Row B, DMatrixSparse C) {
+        UtilEjml.assertTrue(MatrixFeatures_DDRM.isVector(A), "'A' must be a vector");
+        UtilEjml.assertShape(A.getNumElements(), B.numRows, "Length of 'A' vector not equal to number of rows in 'B' matrix");
+        UtilEjml.assertTrue(MatrixFeatures_DDRM.isVector(C), "'C' must be a vector");
+        UtilEjml.assertShape(C.getNumElements(), B.numCols, "Length of 'C' vector not equal to number of columns in 'B' matrix");
+    }
+
+    /**
+     * scalar = A<sup>T</sup>*B*C
+     *
+     * @param A (Input) A vector that has length m.
+     * @param B (Input) A matrix that is m by n.
+     * @param C (Input)  A vector that has length n.
+     */
+    public static double innerProduct( DMatrixSparseCSC A, DMatrixRMaj B, DMatrixSparseCSC C) {
+        checkInnerProductArguments(A, B, C);
+
+        double output = 0.0;
+        for (int i = 0; i < A.nz_length; i++) {
+            int b_offset = A.nz_rows[i] * B.numCols;
+            double sum = 0.0;
+            for (int j = 0; j < C.nz_length; j++) {
+                sum += C.nz_values[j] * B.data[b_offset + C.nz_rows[j]];
+            }
+            output += A.nz_values[i] * sum;
+        }
+        return output;
+    }
+
+    /**
+     * scalar = A<sup>T</sup>*B*A
+     *
+     * @param A (Input) A vector that has length n.
+     * @param B (Input) A matrix that is n by n and symmetrical.
+     */
+    public static double innerProductSelfSymmetrical(DMatrixSparse A, DMatrix1Row B) {
+        checkInnerProductSelfSymmetricalArguments(A, B);
+
+        VectorEntry[] nzValues = nzValues(A);
+
+        double output = 0.0;
+        int size = nzValues.length;
+        for (int i = 0; i < size; i++) {
+            VectorEntry e1 = nzValues[i];
+            int index1 = e1.index;
+            double value1 = e1.value;
+            // matrix diagonal
+            double diagonalValue = B.unsafe_get(index1, index1);
+            double sum = 0.0;
+            for (int j = i + 1; j < size; j++) {
+                VectorEntry e2 = nzValues[j];
+                sum += e2.value * B.unsafe_get(index1, e2.index);
+            }
+            output += Math.pow(value1, 2) * diagonalValue + value1 * (sum + sum);
+        }
+        return output;
+    }
+
+    private static void checkInnerProductSelfSymmetricalArguments(DMatrixSparse A, DMatrix1Row B) {
+        UtilEjml.assertTrue(MatrixFeatures_DDRM.isVector(A), "'A' must be a vector");
+        UtilEjml.assertTrue(MatrixFeatures_DDRM.isSquare(B), "'B' must be a square matrix");
+        UtilEjml.assertShape(A.getNumElements(), B.numRows, "Length of 'A' vector not equal to number of rows / columns in 'B' matrix");
+    }
+
+    /**
+     * scalar = A<sup>T</sup>*B*A
+     *
+     * @param A (Input) A vector that has length n.
+     * @param B (Input) A matrix that is n by n and symmetrical.
+     */
+    public static double innerProductSelfSymmetrical(DMatrixSparseCSC A, DMatrixRMaj B) {
+        checkInnerProductSelfSymmetricalArguments(A, B);
+
+        double output = 0.0;
+        for (int i = 0; i < A.nz_length; i++) {
+            int index1 = A.nz_rows[i];
+            double value1 = A.nz_values[i];
+            int b_offset = index1 * B.numCols;
+            double diagonalValue = B.data[b_offset + index1];
+            double sum = 0.0;
+            for (int j = i + 1; j < A.nz_length; j++) {
+                sum += A.nz_values[j] * B.data[b_offset + A.nz_rows[j]];
+            }
+            output += Math.pow(value1, 2) * diagonalValue + value1 * (sum + sum);
+        }
+        return output;
+    }
+
+    private static class VectorEntry {
+        public final int index;
+        public final double value;
+
+        public VectorEntry(int index, double value) {
+            this.index = index;
+            this.value = value;
+        }
+    }
+
+    private static VectorEntry[] nzValues(DMatrixSparse A) {
+        VectorEntry[] nzValues = new VectorEntry[A.getNonZeroLength()];
+        int i = 0;
+        for (Iterator<DMatrixSparse.CoordinateRealValue> it = A.createCoordinateIterator(); it.hasNext(); ) {
+            DMatrixSparse.CoordinateRealValue crv = it.next();
+            nzValues[i++] = new VectorEntry(crv.row, crv.value);
+        }
+        return nzValues;
     }
 }

--- a/main/ejml-ddense/test/org/ejml/dense/row/mult/TestMatrixVectorMult_DDRM.java
+++ b/main/ejml-ddense/test/org/ejml/dense/row/mult/TestMatrixVectorMult_DDRM.java
@@ -21,10 +21,14 @@ package org.ejml.dense.row.mult;
 import org.ejml.EjmlStandardJUnit;
 import org.ejml.UtilEjml;
 import org.ejml.data.DMatrixRMaj;
+import org.ejml.data.DMatrixSparse;
+import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.UtilTestMatrix;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.dense.row.MatrixFeatures_DDRM;
 import org.ejml.dense.row.RandomMatrices_DDRM;
+import org.ejml.sparse.csc.CommonOps_DSCC;
+import org.ejml.sparse.csc.RandomMatrices_DSCC;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -141,6 +145,56 @@ public class TestMatrixVectorMult_DDRM extends EjmlStandardJUnit {
         System.arraycopy(c.data, 0, _c, offsetC, 5);
 
         found = MatrixVectorMult_DDRM.innerProduct(_a, offsetA, B, _c, offsetC);
+        assertEquals(expected, found, UtilEjml.TEST_F64);
+    }
+
+    @Test void innerProduct_sparse() {
+        DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(10, 1, 6, rand);
+        DMatrixRMaj b = RandomMatrices_DDRM.rectangle(10, 10, rand);
+        DMatrixSparse c = RandomMatrices_DSCC.rectangle(10, 1, 6, rand);
+        DMatrixRMaj c2 = new DMatrixRMaj(c);
+
+        DMatrixRMaj tmp = new DMatrixRMaj(10, 1);
+        CommonOps_DSCC.multTransA(a, b, tmp, null);
+        double expected = CommonOps_DDRM.dot(tmp, c2);
+        double found = MatrixVectorMult_DDRM.innerProduct(a, b, c);
+        assertEquals(expected, found, UtilEjml.TEST_F64);
+    }
+
+    @Test void innerProduct_sparse_csc() {
+        DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(10, 1, 6, rand);
+        DMatrixRMaj b = RandomMatrices_DDRM.rectangle(10, 10, rand);
+        DMatrixSparseCSC c = RandomMatrices_DSCC.rectangle(10, 1, 6, rand);
+        DMatrixRMaj c2 = new DMatrixRMaj(c);
+
+        DMatrixRMaj tmp = new DMatrixRMaj(10, 1);
+        CommonOps_DSCC.multTransA(a, b, tmp, null);
+        double expected = CommonOps_DDRM.dot(tmp, c2);
+        double found = MatrixVectorMult_DDRM.innerProduct(a, b, c);
+        assertEquals(expected, found, UtilEjml.TEST_F64);
+    }
+
+    @Test void innerProduct_sparse_symmetric() {
+        DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(10, 1, 6, rand);
+        DMatrixRMaj a2 = new DMatrixRMaj(a);
+        DMatrixRMaj b = RandomMatrices_DDRM.symmetricPosDef(10, rand);
+
+        DMatrixRMaj tmp = new DMatrixRMaj(10, 1);
+        CommonOps_DSCC.multTransA(a, b, tmp, null);
+        double expected = CommonOps_DDRM.dot(tmp, a2);
+        double found = MatrixVectorMult_DDRM.innerProductSelfSymmetrical((DMatrixSparse) a, b);
+        assertEquals(expected, found, UtilEjml.TEST_F64);
+    }
+
+    @Test void innerProduct_sparse_symmetric_csc() {
+        DMatrixSparseCSC a = RandomMatrices_DSCC.rectangle(10, 1, 6, rand);
+        DMatrixRMaj a2 = new DMatrixRMaj(a);
+        DMatrixRMaj b = RandomMatrices_DDRM.symmetricPosDef(10, rand);
+
+        DMatrixRMaj tmp = new DMatrixRMaj(10, 1);
+        CommonOps_DSCC.multTransA(a, b, tmp, null);
+        double expected = CommonOps_DDRM.dot(tmp, a2);
+        double found = MatrixVectorMult_DDRM.innerProductSelfSymmetrical(a, b);
         assertEquals(expected, found, UtilEjml.TEST_F64);
     }
 

--- a/main/ejml-dsparse/benchmarks/src/org/ejml/sparse/csc/mult/BenchmarkMatrixVectorMult_DDRM_InnerProduct.java
+++ b/main/ejml-dsparse/benchmarks/src/org/ejml/sparse/csc/mult/BenchmarkMatrixVectorMult_DDRM_InnerProduct.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ejml.sparse.csc.mult;
+
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.data.DMatrixSparse;
+import org.ejml.data.DMatrixSparseCSC;
+import org.ejml.dense.row.RandomMatrices_DDRM;
+import org.ejml.dense.row.mult.MatrixVectorMult_DDRM;
+import org.ejml.sparse.csc.RandomMatrices_DSCC;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+public class BenchmarkMatrixVectorMult_DDRM_InnerProduct {
+
+    @Param({"5", "1000", "3000"})
+    public int size;
+
+    @Param({"0.2", "0.4", "0.6", "0.8"})
+    public double density;
+
+    private DMatrixSparse A;
+    private DMatrixRMaj B;
+    private double[] a;
+
+    @Setup
+    public void setUp() {
+        Random rand = new Random(234);
+        B = RandomMatrices_DDRM.symmetricPosDef(size, rand);
+        A = RandomMatrices_DSCC.rectangle(size, 1, (int) (density * size), rand);
+        a = new DMatrixRMaj(A).data;
+    }
+
+    @Benchmark public void innerProduct() { MatrixVectorMult_DDRM.innerProduct(a, 0, B, a, 0);}
+    @Benchmark public void innerProduct_sparse() { MatrixVectorMult_DDRM.innerProduct(A, B, A);}
+    @Benchmark public void innerProduct_sparse_csc() { MatrixVectorMult_DDRM.innerProduct((DMatrixSparseCSC) A, B, (DMatrixSparseCSC) A);}
+    @Benchmark public void innerProduct_symmetric_sparse() { MatrixVectorMult_DDRM.innerProductSelfSymmetrical(A, B);}
+    @Benchmark public void innerProduct_symmetric_sparse_csc() { MatrixVectorMult_DDRM.innerProductSelfSymmetrical((DMatrixSparseCSC) A, B);}
+
+    public static void main( String[] args ) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(BenchmarkMatrixVectorMult_DDRM_InnerProduct.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
PR for #180 

The new version of `innerProduct` will be specialised to take in sparse vectors for A and C, and a matrix B.

scalar = A<sup>T</sup>^ * B * C

By looping through only non-zero elements of the vectors, avoids a lot of unnecessary operations and have a significant performance improvement when used with sparse vectors.

And `innerProductSelfSymmetrical`, specialised to take in sparse vector A, and a positive semi-definite covariance matrix B.

scalar = A<sup>T</sup> * B * A

Further enhances the innerProduct, utilising the matrix symmetry, it will calculate the product using just the lower (or upper) triangle, multiply this by 2, then add to the product of the matrix diagonal.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please make sure:
- [X] Your code is covered by tests
- [X] You ran `./gradlew spotlessJavaApply`