### PR TITLE
Fix silenced exception in concurrent executions and bugfix for concurrent multTransA_reorder

### DIFF
--- a/main/ejml-core/src/pabeles/concurrency/ConcurrencyOps.java
+++ b/main/ejml-core/src/pabeles/concurrency/ConcurrencyOps.java
@@ -62,7 +62,7 @@ public class ConcurrencyOps {
         try {
             pool.submit(() -> IntStream.range(start, endExclusive).parallel().forEach(consumer)).get();
         } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -84,7 +84,7 @@ public class ConcurrencyOps {
             int iterations = range/step + ((range%step == 0) ? 0 : 1);
             pool.submit(() -> IntStream.range(0, iterations).parallel().forEach(i -> consumer.accept(start + i*step))).get();
         } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -105,7 +105,7 @@ public class ConcurrencyOps {
         try {
             pool.submit(new IntObjectTask<>(start, endExclusive, step, pool.getParallelism(), -1, workspace, consumer)).get();
         } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -142,7 +142,7 @@ public class ConcurrencyOps {
         try {
             pool.submit(new IntRangeTask(start, endExclusive, block, consumer)).get();
         } catch (InterruptedException | ExecutionException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/main/ejml-ddense/src/org/ejml/dense/row/mult/MatrixMatrixMult_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/mult/MatrixMatrixMult_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.dense.row.mult;
 
 import org.ejml.UtilEjml;

--- a/main/ejml-ddense/src/org/ejml/dense/row/mult/MatrixMatrixMult_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/mult/MatrixMatrixMult_DDRM.java
@@ -176,7 +176,7 @@ public class MatrixMatrixMult_DDRM {
             CommonOps_DDRM.fill(C, 0);
             return;
         }
-        //CONCURRENT_BELOW EjmlConcurrency.loopFor(0, A.numRows, i -> {
+        //CONCURRENT_BELOW EjmlConcurrency.loopFor(0, A.numCols, i -> {
         for (int i = 0; i < A.numCols; i++) {
             int indexC_start = i*C.numCols;
 

--- a/main/ejml-simple/test/org/ejml/simple/ops/TestSimpleOperations_DDRM.java
+++ b/main/ejml-simple/test/org/ejml/simple/ops/TestSimpleOperations_DDRM.java
@@ -18,9 +18,13 @@
 
 package org.ejml.simple.ops;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.ejml.data.DMatrixRMaj;
+import org.ejml.dense.row.MatrixFeatures_DDRM;
 import org.ejml.dense.row.RandomMatrices_DDRM;
 import org.ejml.simple.SimpleOperations;
+import org.junit.jupiter.api.Test;
 
 class TestSimpleOperations_DDRM extends BaseSimpleOperationsChecks<DMatrixRMaj> {
     @Override public SimpleOperations<DMatrixRMaj> createOps() {
@@ -29,5 +33,22 @@ class TestSimpleOperations_DDRM extends BaseSimpleOperationsChecks<DMatrixRMaj> 
 
     @Override public DMatrixRMaj randomRect( int numRows, int numCols ) {
         return RandomMatrices_DDRM.rectangle(numRows, numCols, rand);
+    }
+    
+    @Test void multTransA() {
+    	SimpleOperations<DMatrixRMaj> ops = createOps();
+    	for(int nRows : new int[] {1_000, 10_000, 100_000}) {
+    		DMatrixRMaj randMat = randomRect(nRows, 1);
+    		DMatrixRMaj ones = new DMatrixRMaj(nRows,1);
+    		ops.fill(ones, (double) 1.0);
+
+    		DMatrixRMaj expected = new DMatrixRMaj(1, 1);
+    		expected.set(0, (double) ops.elementSum(randMat));
+
+    		DMatrixRMaj result = new DMatrixRMaj(1, 1);
+    		ops.multTransA(randMat, ones, result);
+
+    		assertTrue(MatrixFeatures_DDRM.isIdentical(expected, result, (double) 1e-20));
+    	}
     }
 }


### PR DESCRIPTION
This PR fixes the issues described in #182.
The discovery of a bug in `MatrixMatrixMult_MT_DDRM.multTransA_reorder(a,b,c)` led to the discovery of dangerous behavior of `ConcurrencyOps.loopFor` methods. These methods catch exceptions that are thown in threadpool-submitted tasks and do not propagate these exceptions further as would be the case for the single-threaded counter part.

This PR fixes the bug, changes behavior of `loopFor` methods to propagate exceptions, and adds a unit test for `SimpleOperations_DDRM.multTransA` (which calls the bug affected method under the hood).

- [x] Your code is covered by tests
- [x] You ran `./gradlew spotlessJavaApply`