### PR TITLE
isDiagonalPositive now acts as the documentation describes

### DIFF
--- a/change.txt
+++ b/change.txt
@@ -9,6 +9,9 @@ Date format: year/month/day
   * Thanks to hageldave for finding and fixing the problem
 - Added new sparse inner product
   * Thanks spensonshih for the PR
+- MatrixFeatures_DDRM.isDiagonalPositive incorrectly tested for >= 0 and not > 0.
+  * Thanks TobiasLangner-TomTom for reporting the issue
+- Added MatrixFeatures_DDRM.isDiagonalNotNegative
 
 - TODO concurrency for complex https://github.com/lessthanoptimal/ejml/issues/176
 - TODO Support Java Modules

--- a/main/ejml-ddense/src/org/ejml/dense/row/CovarianceOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CovarianceOps_DDRM.java
@@ -32,7 +32,7 @@ import java.util.Random;
  * @author Peter Abeles
  */
 public class CovarianceOps_DDRM {
-    private CovarianceOps_DDRM(){}
+    private CovarianceOps_DDRM() {}
 
     public static double TOL = UtilEjml.TESTP_F64;
 
@@ -48,10 +48,11 @@ public class CovarianceOps_DDRM {
     }
 
     /**
-     * Performs a variety of tests to see if the provided matrix is a valid
-     * covariance matrix.
+     * Performs a variety of tests to see if the provided matrix is a valid covariance matrix, performing
+     * the fastest checks first.
      *
-     * @return 0 = is valid 1 = failed positive diagonal, 2 = failed on symmetry, 2 = failed on positive definite
+     * @return 0 = is valid 1 = failed: has negative diagonals, 2 = failed: not symmetry,
+     * 3 = failed: not semi positive definite
      */
     public static int isValid( DMatrixRMaj cov ) {
         if (!MatrixFeatures_DDRM.isDiagonalNotNegative(cov))

--- a/main/ejml-ddense/src/org/ejml/dense/row/CovarianceOps_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/CovarianceOps_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -44,7 +44,7 @@ public class CovarianceOps_DDRM {
      * @return true if valid and false if invalid
      */
     public static boolean isValidFast( DMatrixRMaj cov ) {
-        return MatrixFeatures_DDRM.isDiagonalPositive(cov);
+        return MatrixFeatures_DDRM.isDiagonalNotNegative(cov);
     }
 
     /**
@@ -54,7 +54,7 @@ public class CovarianceOps_DDRM {
      * @return 0 = is valid 1 = failed positive diagonal, 2 = failed on symmetry, 2 = failed on positive definite
      */
     public static int isValid( DMatrixRMaj cov ) {
-        if (!MatrixFeatures_DDRM.isDiagonalPositive(cov))
+        if (!MatrixFeatures_DDRM.isDiagonalNotNegative(cov))
             return 1;
 
         if (!MatrixFeatures_DDRM.isSymmetric(cov, TOL))

--- a/main/ejml-ddense/src/org/ejml/dense/row/MatrixFeatures_DDRM.java
+++ b/main/ejml-ddense/src/org/ejml/dense/row/MatrixFeatures_DDRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -40,7 +40,7 @@ import org.ejml.interfaces.decomposition.SingularValueDecomposition_F64;
  * @author Peter Abeles
  */
 public class MatrixFeatures_DDRM {
-    private MatrixFeatures_DDRM(){}
+    private MatrixFeatures_DDRM() {}
 
     /**
      * Checks to see if any element in the matrix is NaN.
@@ -551,6 +551,20 @@ public class MatrixFeatures_DDRM {
     }
 
     /**
+     * Checks to see if diagonal element are all not negative, i.e. greater than or equal to 0.
+     *
+     * @param a A matrix. Not modified.
+     * @return True if diagonal element are all not negative. False otherwise.
+     */
+    public static boolean isDiagonalNotNegative( DMatrixRMaj a ) {
+        for (int i = 0; i < a.numRows; i++) {
+            if (!(a.get(i, i) >= 0))
+                return false;
+        }
+        return true;
+    }
+
+    /**
      * Checks to see if all the diagonal elements in the matrix are positive.
      *
      * @param a A matrix. Not modified.
@@ -558,7 +572,7 @@ public class MatrixFeatures_DDRM {
      */
     public static boolean isDiagonalPositive( DMatrixRMaj a ) {
         for (int i = 0; i < a.numRows; i++) {
-            if (!(a.get(i, i) >= 0))
+            if (!(a.get(i, i) > 0))
                 return false;
         }
         return true;

--- a/main/ejml-ddense/test/org/ejml/dense/row/TestMatrixFeatures_DDRM.java
+++ b/main/ejml-ddense/test/org/ejml/dense/row/TestMatrixFeatures_DDRM.java
@@ -106,11 +106,28 @@ public class TestMatrixFeatures_DDRM extends EjmlStandardJUnit {
         DMatrixRMaj m = CommonOps_DDRM.identity(3);
         assertTrue(MatrixFeatures_DDRM.isDiagonalPositive(m));
 
+        m.set(1, 1, 0);
+        assertFalse(MatrixFeatures_DDRM.isDiagonalPositive(m));
+
         m.set(1, 1, -1);
         assertFalse(MatrixFeatures_DDRM.isDiagonalPositive(m));
 
         m.set(1, 1, Double.NaN);
         assertFalse(MatrixFeatures_DDRM.isDiagonalPositive(m));
+    }
+
+    @Test void isDiagonalNotNegative() {
+        DMatrixRMaj m = CommonOps_DDRM.identity(3);
+        assertTrue(MatrixFeatures_DDRM.isDiagonalNotNegative(m));
+
+        m.set(1, 1, 0);
+        assertTrue(MatrixFeatures_DDRM.isDiagonalNotNegative(m));
+
+        m.set(1, 1, -1);
+        assertFalse(MatrixFeatures_DDRM.isDiagonalNotNegative(m));
+
+        m.set(1, 1, Double.NaN);
+        assertFalse(MatrixFeatures_DDRM.isDiagonalNotNegative(m));
     }
 
     @Test void isSymmetric() {


### PR DESCRIPTION
isDiagonalNotNegative has been added with the same behavior as the original implementation

Thank you for your contribution to the EJML project.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please make sure:
- [x] Your code is covered by tests
- [x] You ran `./gradlew spotlessJavaApply`