### PR TITLE
Documentation additions and changes for SimpleMatrix

### DIFF
--- a/main/ejml-simple/src/org/ejml/simple/ConstMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/ConstMatrix.java
@@ -188,7 +188,7 @@ public interface ConstMatrix<T extends ConstMatrix<T>> {
     T plus( double beta, ConstMatrix<?> B );
 
     /**
-     * Computes the dot product (a.k.a. inner product) between this vector and vector 'v'.
+     * Computes the dot product (or inner product) between this vector and vector 'v'.
      *
      * @param v The second vector in the dot product. Not modified.
      * @return dot product

--- a/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleBase.java
@@ -104,32 +104,80 @@ public abstract class SimpleBase<T extends SimpleBase<T>> implements ConstMatrix
      * when an operation is needed that is not provided by this class.
      * </p>
      *
-     * @return Reference to the internal DMatrixRMaj.
+     * @return Reference to the internal matrix.
      */
     public <InnerType extends Matrix> InnerType getMatrix() {
         return (InnerType)mat;
     }
 
+    /**
+     * <p>
+     * Returns a reference to the matrix that it uses internally if this is a {@link DMatrixRMaj}.
+     * Otherwise attempts to convert the internal matrix to a {@link DMatrixRMaj}.
+     * </p>
+     *
+     * @return Reference to the internal matrix or converted internal matrix.
+     */
     public DMatrixRMaj getDDRM() {
         return (mat.getType() == MatrixType.DDRM) ? (DMatrixRMaj)mat : (DMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.DDRM);
     }
 
+    /**
+     * <p>
+     * Returns a reference to the matrix that it uses internally if this is a {@link FMatrixRMaj}.
+     * Otherwise attempts to convert the internal matrix to a {@link FMatrixRMaj}.
+     * </p>
+     *
+     * @return Reference to the internal matrix or converted internal matrix.
+     */
     public FMatrixRMaj getFDRM() {
         return (mat.getType() == MatrixType.FDRM) ? (FMatrixRMaj)mat : (FMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.FDRM);
     }
 
+    /**
+     * <p>
+     * Returns a reference to the matrix that it uses internally if this is a {@link ZMatrixRMaj}.
+     * Otherwise attempts to convert the internal matrix to a {@link ZMatrixRMaj}.
+     * </p>
+     *
+     * @return Reference to the internal matrix or converted internal matrix.
+     */
     public ZMatrixRMaj getZDRM() {
         return (mat.getType() == MatrixType.ZDRM) ? (ZMatrixRMaj)mat : (ZMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.ZDRM);
     }
 
+    /**
+     * <p>
+     * Returns a reference to the matrix that it uses internally if this is a {@link CMatrixRMaj}.
+     * Otherwise attempts to convert the internal matrix to a {@link CMatrixRMaj}.
+     * </p>
+     *
+     * @return Reference to the internal matrix or converted internal matrix.
+     */
     public CMatrixRMaj getCDRM() {
         return (mat.getType() == MatrixType.CDRM) ? (CMatrixRMaj)mat : (CMatrixRMaj)ConvertMatrixType.convert(mat, MatrixType.CDRM);
     }
 
+    /**
+     * <p>
+     * Returns a reference to the matrix that it uses internally if this is a {@link DMatrixSparseCSC}.
+     * Otherwise attempts to convert the internal matrix to a {@link DMatrixSparseCSC}.
+     * </p>
+     *
+     * @return Reference to the internal matrix or converted internal matrix.
+     */
     public DMatrixSparseCSC getDSCC() {
         return (mat.getType() == MatrixType.DSCC) ? (DMatrixSparseCSC)mat : (DMatrixSparseCSC)ConvertMatrixType.convert(mat, MatrixType.DSCC);
     }
 
+    /**
+     * <p>
+     * Returns a reference to the matrix that it uses internally if this is a {@link FMatrixSparseCSC}.
+     * Otherwise attempts to convert the internal matrix to a {@link FMatrixSparseCSC}.
+     * </p>
+     *
+     * @return Reference to the internal matrix or converted internal matrix.
+     */
     public FMatrixSparseCSC getFSCC() {
         return (mat.getType() == MatrixType.FSCC) ? (FMatrixSparseCSC)mat : (FMatrixSparseCSC)ConvertMatrixType.convert(mat, MatrixType.FSCC);
     }

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -244,7 +244,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *     <tr><td>{@link #scaleComplex(double, double)}</td>
  *     <td>Multiply by a complex scalar value.</td></tr>
  *     <tr><td>{@link #divide(double)}</td>
- *     <td>Divided by a scalar value.</td></tr>
+ *     <td>Divide by a scalar value.</td></tr>
  *     <tr><td>{@link #mult(ConstMatrix)}</td>
  *     <td>Multiply with another matrix.</td></tr>
  *     <tr><td>{@link #dot(ConstMatrix)}</td>

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -40,13 +40,13 @@ import java.util.concurrent.ThreadLocalRandom;
  * management and writing of code in general. It also allows operations to be chained, as is shown
  * below:<br>
  * <br>
- * SimpleMatrix K = P.mult(H.transpose().mult(S.invert()));
+ * {@code SimpleMatrix K = P.mult(H.transpose().mult(S.invert()));}
  * </p>
  *
  * <p>
  * Working with both a primitive matrix and SimpleMatrix in the same code base is easy.
- * To access the internal DMatrixRMaj in a SimpleMatrix simply call {@link SimpleMatrix#getMatrix()}.
- * To turn a DMatrixRMaj into a SimpleMatrix use {@link SimpleMatrix#wrap(org.ejml.data.Matrix)}. Not
+ * To access the internal Matrix in a SimpleMatrix simply call {@link SimpleMatrix#getMatrix()}.
+ * To turn a Matrix into a SimpleMatrix use {@link SimpleMatrix#wrap(org.ejml.data.Matrix)}. Not
  * all operations in EJML are provided for SimpleMatrix, but can be accessed by extracting the internal
  * matrix.
  * </p>
@@ -74,13 +74,13 @@ import java.util.concurrent.ThreadLocalRandom;
  * </p>
  *
  * <p>
- * If SimpleMatrix is extended then the protected function {link #createMatrix} should be extended and return
+ * If SimpleMatrix is extended then the protected function {@link #createMatrix} should be extended and return
  * the child class. The results of SimpleMatrix operations will then be of the correct matrix type.
  * </p>
  *
  * <p>
- * The object oriented approach used in SimpleMatrix was originally inspired by Jama.
- * http://math.nist.gov/javanumerics/jama/
+ * The object oriented approach used in SimpleMatrix was originally inspired by
+ * <a href=http://math.nist.gov/javanumerics/jama/>JAMA</a>.
  * </p>
  *
  * @author Peter Abeles
@@ -203,12 +203,19 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
         setMatrix(new DMatrixRMaj(numRows, numCols));
     }
 
-    public SimpleMatrix( int numRows, int numCols, Class type ) {
+    /**
+     * Creates a new matrix that is initially set to zero with the specified dimensions and type.
+     *
+     * @param numRows The number of rows in the matrix.
+     * @param numCols The number of columns in the matrix.
+     * @param type The matrix type
+     */
+    public SimpleMatrix( int numRows, int numCols, Class<?> type ) {
         this(numRows, numCols, MatrixType.lookup(type));
     }
 
     /**
-     * Create a simple matrix of the specified type
+     * Creates a new matrix that is initially set to zero with the specified dimensions and type.
      *
      * @param numRows The number of rows in the matrix.
      * @param numCols The number of columns in the matrix.
@@ -274,10 +281,11 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Returns a filled matrix (numRows x numCols) of the value a.
-     * @param numRows The number of numRows.
-     * @param numCols The number of columns.
-     * @param a The number to fill the matrix with.
+     * Creates a new matrix filled with the specified value. This will wrap a {@link DMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the matrix.
+     * @param numCols The number of columns in the matrix.
+     * @param a The value to fill the matrix with.
      * @return A matrix filled with the value a.
      */
     public static SimpleMatrix filled( int numRows, int numCols, double a ) {
@@ -287,9 +295,10 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Returns a matrix of ones.
-     * @param numRows The number of numRows.
-     * @param numCols The number of columns.
+     * Creates a new matrix filled with ones. This will wrap a {@link DMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the matrix.
+     * @param numCols The number of columns in the matrix.
      * @return A matrix of ones.
      */
     public static SimpleMatrix ones( int numRows, int numCols ) {
@@ -297,7 +306,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a new identity matrix with the specified size.
+     * Creates a new identity matrix with the specified size. This will wrap a {@link DMatrixRMaj}.
      *
      * @param width The width and height of the matrix.
      * @return An identity matrix.
@@ -307,6 +316,13 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
         return identity(width, DMatrixRMaj.class);
     }
 
+    /**
+     * Creates a new identity matrix with the specified size and type.
+     *
+     * @param width The width and height of the matrix.
+     * @param type The matrix type
+     * @return An identity matrix.
+     */
     public static SimpleMatrix identity( int width, Class<?> type ) {
         var ret = new SimpleMatrix(width, width, type);
         ret.ops.setIdentity(ret.mat);
@@ -316,7 +332,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     /**
      * <p>
      * Creates a matrix where all but the diagonal elements are zero. The values
-     * of the diagonal elements are specified by the parameter 'vals'.
+     * of the diagonal elements are specified by the parameter 'vals'. This will wrap a {@link DMatrixRMaj}.
      * </p>
      *
      * <p>
@@ -332,7 +348,12 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a real valued diagonal matrix of the specified type
+     * Creates a matrix where all but the diagonal elements are zero. The values
+     * of the diagonal elements are specified by the parameter 'vals'.
+     *
+     * @param type The matrix type
+     * @param vals The values of the diagonal elements.
+     * @return A diagonal matrix.
      */
     public static SimpleMatrix diag( Class<?> type, double... vals ) {
         var M = new SimpleMatrix(vals.length, vals.length, type);
@@ -343,16 +364,16 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * <p>
-     * Creates a new SimpleMatrix with random elements drawn from a uniform distribution from minValue to maxValue.
-     * </p>
+     * Creates a random matrix with values drawn from the uniform distribution from minValue (inclusive) to
+     * maxValue (exclusive). This will wrap a {@link DMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
      * @param numCols The number of columns in the new matrix
      * @param minValue Lower bound
      * @param maxValue Upper bound
-     * @param rand The random number generator that's used to fill the matrix. @return The new random matrix.
-     * @see RandomMatrices_DDRM#fillUniform(DMatrixRMaj, java.util.Random)
+     * @param rand The random number generator that's used to fill the matrix.
+     * @return The new random matrix.
+     * @see RandomMatrices_DDRM#fillUniform(DMatrixD1, double, double, java.util.Random)
      */
     public static SimpleMatrix random_DDRM( int numRows, int numCols, double minValue, double maxValue, Random rand ) {
         var ret = new SimpleMatrix(numRows, numCols);
@@ -361,21 +382,39 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a DDRM random matrix with values from 0.0 to 1.0. Random number generator is
-     * {@link ThreadLocalRandom#current()}.
+     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
+     * @see #random_DDRM(int, int)
      */
     public static SimpleMatrix random( int numRows, int numCols ) {
         return random_DDRM(numRows, numCols, 0.0, 1.0, ThreadLocalRandom.current());
     }
 
     /**
-     * Creates a DDRM random matrix with values from 0.0 to 1.0. Random number generator is
-     * {@link ThreadLocalRandom#current()}.
+     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link DMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
      */
     public static SimpleMatrix random_DDRM( int numRows, int numCols ) {
         return random_DDRM(numRows, numCols, 0.0, 1.0, ThreadLocalRandom.current());
     }
 
+    /**
+     * Creates a random matrix with values drawn from the uniform distribution from minValue (inclusive) to
+     * maxValue (exclusive). This will wrap a {@link FMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
+     * @param minValue Lower bound
+     * @param maxValue Upper bound
+     * @param rand The random number generator that's used to fill the matrix.
+     * @return The new random matrix.
+     * @see RandomMatrices_FDRM#fillUniform(FMatrixD1, float, float, java.util.Random)
+     */
     public static SimpleMatrix random_FDRM( int numRows, int numCols, float minValue, float maxValue, Random rand ) {
         var ret = new SimpleMatrix(numRows, numCols, FMatrixRMaj.class);
         RandomMatrices_FDRM.fillUniform((FMatrixRMaj)ret.mat, minValue, maxValue, rand);
@@ -383,13 +422,28 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a FDRM random matrix with values from 0.0 to 1.0. Random number generator is
-     * {@link ThreadLocalRandom#current()}.
+     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link FMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
      */
     public static SimpleMatrix random_FDRM( int numRows, int numCols ) {
         return random_FDRM(numRows, numCols, 0.0f, 1.0f, ThreadLocalRandom.current());
     }
 
+    /**
+     * Creates a random matrix with real and complex components drawn from the uniform distribution from
+     * minValue (inclusive) to maxValue (exclusive). This will wrap a {@link ZMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
+     * @param minValue Lower bound
+     * @param maxValue Upper bound
+     * @param rand The random number generator that's used to fill the matrix.
+     * @return The new random matrix.
+     * @see RandomMatrices_ZDRM#fillUniform(ZMatrixD1, double, double, java.util.Random)
+     */
     public static SimpleMatrix random_ZDRM( int numRows, int numCols, double minValue, double maxValue, Random rand ) {
         var ret = new SimpleMatrix(numRows, numCols, MatrixType.ZDRM);
         RandomMatrices_ZDRM.fillUniform((ZMatrixRMaj)ret.mat, minValue, maxValue, rand);
@@ -397,13 +451,28 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a ZDRM random matrix with values from 0.0 to 1.0. Random number generator is
-     * {@link ThreadLocalRandom#current()}.
+     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link ZMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
      */
     public static SimpleMatrix random_ZDRM( int numRows, int numCols ) {
         return random_ZDRM(numRows, numCols, 0.0, 1.0, ThreadLocalRandom.current());
     }
 
+    /**
+     * Creates a random matrix with real and complex components drawn from the uniform distribution from
+     * minValue (inclusive) to maxValue (exclusive). This will wrap a {@link CMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
+     * @param minValue Lower bound
+     * @param maxValue Upper bound
+     * @param rand The random number generator that's used to fill the matrix.
+     * @return The new random matrix.
+     * @see RandomMatrices_CDRM#fillUniform(CMatrixD1, float, float, java.util.Random)
+     */
     public static SimpleMatrix random_CDRM( int numRows, int numCols, float minValue, float maxValue, Random rand ) {
         var ret = new SimpleMatrix(numRows, numCols, MatrixType.CDRM);
         RandomMatrices_CDRM.fillUniform((CMatrixRMaj)ret.mat, minValue, maxValue, rand);
@@ -411,8 +480,11 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a CDRM random matrix with values from 0.0 to 1.0. Random number generator is
-     * {@link ThreadLocalRandom#current()}.
+     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link CMatrixRMaj}.
+     *
+     * @param numRows The number of rows in the new matrix
+     * @param numCols The number of columns in the new matrix
      */
     public static SimpleMatrix random_CDRM( int numRows, int numCols ) {
         return random_CDRM(numRows, numCols, 0.0f, 1.0f, ThreadLocalRandom.current());
@@ -425,6 +497,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
      * </p>
      *
      * @param covariance Covariance of the multivariate normal distribution
+     * @param random The random number generator that's used to fill the matrix.
      * @return Vector randomly drawn from the distribution
      * @see CovarianceRandomDraw_DDRM
      */
@@ -498,4 +571,5 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
 //
 //        return ret;
 //    }
+
 }

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -52,14 +52,26 @@ import java.util.concurrent.ThreadLocalRandom;
  * </p>
  *
  * <p>
- * EXTENDING: SimpleMatrix contains a list of narrowly focused functions for linear algebra. To harness
+ * The object oriented approach used in SimpleMatrix was originally inspired by
+ * <a href=http://math.nist.gov/javanumerics/jama/>JAMA</a>.
+ * </p>
+ *
+ * <h3>Extending</h3>
+ * <p>
+ * SimpleMatrix contains a list of narrowly focused functions for linear algebra. To harness
  * the functionality for another application and to the number of functions it supports it is recommended
  * that one extends {@link SimpleBase} instead. This way the returned matrix type's of SimpleMatrix functions
  * will be of the appropriate types. See StatisticsMatrix inside of the examples directory.
  * </p>
  *
  * <p>
- * PERFORMANCE: The disadvantage of using this class is that it is more resource intensive, since
+ * If SimpleMatrix is extended then the protected function {@link #createMatrix} should be extended and return
+ * the child class. The results of SimpleMatrix operations will then be of the correct matrix type.
+ * </p>
+ *
+ * <h3>Performance</h3>
+ * <p>
+ * The disadvantage of using this class is that it is more resource intensive, since
  * it creates a new matrix each time an operation is performed. This makes the JavaVM work harder and
  * Java automatically initializes the matrix to be all zeros. Typically operations on small matrices
  * or operations that have a runtime linear with the number of elements are the most affected. More
@@ -73,15 +85,196 @@ import java.util.concurrent.ThreadLocalRandom;
  * neck is a more computationally complex operation. The best approach is benchmark and then optimize the code.
  * </p>
  *
- * <p>
- * If SimpleMatrix is extended then the protected function {@link #createMatrix} should be extended and return
- * the child class. The results of SimpleMatrix operations will then be of the correct matrix type.
- * </p>
+ * <h3>Creating matrices</h3>
+ * <ul>
+ *     <li>{@link #SimpleMatrix()}</li>
+ *     <li>{@link #SimpleMatrix(double[])}</li>
+ *     <li>{@link #SimpleMatrix(double[][])}</li>
+ *     <li>{@link #SimpleMatrix(float[])}</li>
+ *     <li>{@link #SimpleMatrix(float[][])}</li>
+ *     <li>{@link #SimpleMatrix(int, int)}</li>
+ *     <li>{@link #SimpleMatrix(int, int, boolean, double...)}</li>
+ *     <li>{@link #SimpleMatrix(int, int, boolean, float...)}</li>
+ *     <li>{@link #SimpleMatrix(int, int, Class)}</li>
+ *     <li>{@link #SimpleMatrix(int, int, MatrixType)}</li>
+ *     <li>{@link #SimpleMatrix(Matrix)}</li>
+ *     <li>{@link #SimpleMatrix(SimpleMatrix)}</li>
+ *     <li>{@link #wrap(Matrix)}</li>
+ *     <li>{@link #filled(int, int, double)}</li>
+ *     <li>{@link #ones(int, int)}</li>
+ *     <li>{@link #diag(double...)}</li>
+ *     <li>{@link #diag(Class, double...)}</li>
+ *     <li>{@link #identity(int)}</li>
+ *     <li>{@link #identity(int, Class)}</li>
+ *     <li>{@link #random(int, int)}</li>
+ *     <li>{@link #random_DDRM(int, int, double, double, Random)}</li>
+ *     <li>{@link #random_DDRM(int, int)}</li>
+ *     <li>{@link #random_FDRM(int, int, float, float, Random)}</li>
+ *     <li>{@link #random_FDRM(int, int)}</li>
+ *     <li>{@link #random_ZDRM(int, int, double, double, Random)}</li>
+ *     <li>{@link #random_ZDRM(int, int)}</li>
+ *     <li>{@link #random_CDRM(int, int, float, float, Random)}</li>
+ *     <li>{@link #random_CDRM(int, int)}</li>
+ *     <li>{@link #randomNormal(SimpleMatrix, Random)}</li>
+ *     <li>{@link #createLike()}</li>
+ *     <li>{@link #copy()}</li>
+ * </ul>
  *
- * <p>
- * The object oriented approach used in SimpleMatrix was originally inspired by
- * <a href=http://math.nist.gov/javanumerics/jama/>JAMA</a>.
- * </p>
+ * <ul>
+ *     <li>{@link #createLike()}</li>
+ *     <li>{@link #copy()}</li>
+ * </ul>
+ *
+ * <h3>Getting elements, rows and columns</h3>
+ * <ul>
+ *     <li>{@link #get(int)}</li>
+ *     <li>{@link #get(int, int)}</li>
+ *     <li>{@link #get(int, int, Complex_F64)}</li>
+ *     <li>{@link #getReal(int, int)}</li>
+ *     <li>{@link #getImaginary(int, int)}</li>
+ *     <li>{@link #getRow(int)} (int)}</li>
+ *     <li>{@link #getColumn(int)}</li>
+ *     <li>{@link #rows(int, int)} (int)}</li>
+ *     <li>{@link #cols(int, int)}</li>
+ *     <li>{@link #extractVector(boolean, int)}</li>
+ *     <li>{@link #extractMatrix(int, int, int, int)}</li>
+ *     <li>{@link #diag()}</li>
+ * </ul>
+ *
+ * <h3>Setting elements, rows and columns</h3>
+ * <ul>
+ *     <li>{@link #set(int, double)}</li>
+ *     <li>{@link #set(int, int, double)}</li>
+ *     <li>{@link #set(int, int, Complex_F64)}</li>
+ *     <li>{@link #set(int, int, double, double)}</li>
+ *     <li>{@link #setRow(int, int, double...)}</li>
+ *     <li>{@link #setRow(int, ConstMatrix)}</li>
+ *     <li>{@link #setColumn(int, int, double...)}</li>
+ *     <li>{@link #setColumn(int, ConstMatrix)}</li>
+ *     <li>{@link #setTo(SimpleBase)}</li>
+ *     <li>{@link #insertIntoThis(int, int, SimpleBase)}</li>
+ *     <li>{@link #fill(double)}</li>
+ *     <li>{@link #fillComplex(double, double)}</li>
+ *     <li>{@link #zero()}</li>
+ * </ul>
+ *
+ * <h3>Matrix arithmetic</h3>
+ * <ul>
+ *     <li>{@link #plus(double)}</li>
+ *     <li>{@link #plusComplex(double, double)}</li>
+ *     <li>{@link #plus(ConstMatrix)}</li>
+ *     <li>{@link #plus(double, ConstMatrix)}</li>
+ *     <li>{@link #minus(double)}</li>
+ *     <li>{@link #minusComplex(double, double)}</li>
+ *     <li>{@link #minus(ConstMatrix)}</li>
+ *     <li>{@link #scale(double)}</li>
+ *     <li>{@link #scaleComplex(double, double)}</li>
+ *     <li>{@link #mult(ConstMatrix)}</li>
+ *     <li>{@link #dot(ConstMatrix)}</li>
+ *     <li>{@link #divide(double)}</li>
+ *     <li>{@link #negative()}</li>
+ *     <li>{@link #real()}</li>
+ *     <li>{@link #imaginary()}</li>
+ *     <li>{@link #magnitude()}</li>
+ *     <li>{@link #transpose()}</li>
+ *     <li>{@link #transposeConjugate()}</li>
+ * </ul>
+ *
+ * <h3>Elementwise operations</h3>
+ * <ul>
+ *     <li>{@link #elementMult(ConstMatrix)}</li>
+ *     <li>{@link #elementDiv(ConstMatrix)}</li>
+ *     <li>{@link #elementPower(double)}</li>
+ *     <li>{@link #elementPower(ConstMatrix)}</li>
+ *     <li>{@link #elementExp()}</li>
+ *     <li>{@link #elementLog()}</li>
+ *     <li>{@link #elementOp(SimpleOperations.ElementOpReal)}</li>
+ *     <li>{@link #elementOp(SimpleOperations.ElementOpComplex)}</li>
+ * </ul>
+ *
+ * <h3>Aggregations</h3>
+ * <ul>
+ *     <li>{@link #elementSum()}</li>
+ *     <li>{@link #elementSumComplex()}</li>
+ *     <li>{@link #elementMax()}</li>
+ *     <li>{@link #elementMaxAbs()}</li>
+ *     <li>{@link #elementMin()}</li>
+ *     <li>{@link #elementMinAbs()}</li>
+ * </ul>
+ *
+ * <h3>Linear algebra</h3>
+ * <ul>
+ *     <li>{@link #solve(ConstMatrix)}</li>
+ *     <li>{@link #invert()}</li>
+ *     <li>{@link #pseudoInverse()}</li>
+ *     <li>{@link #kron(ConstMatrix)}</li>
+ *     <li>{@link #determinant()}</li>
+ *     <li>{@link #determinantComplex()}</li>
+ *     <li>{@link #trace()}</li>
+ *     <li>{@link #traceComplex()}</li>
+ *     <li>{@link #normF()}</li>
+ *     <li>{@link #conditionP2()}</li>
+ *     <li>{@link #eig()}</li>
+ *     <li>{@link #svd()}</li>
+ *     <li>{@link #svd(boolean)}</li>
+ * </ul>
+ *
+ * <h3>Combining matrices</h3>
+ * <ul>
+ *     <li>{@link #combine(int, int, ConstMatrix)}</li>
+ *     <li>{@link #concatRows(ConstMatrix[])}</li>
+ *     <li>{@link #concatColumns(ConstMatrix[])}</li>
+ * </ul>
+ *
+ * <h3>Matrix properties</h3>
+ * <ul>
+ *     <li>{@link #getNumRows()}</li>
+ *     <li>{@link #getNumCols()}</li>
+ *     <li>{@link #getType()}</li>
+ *     <li>{@link #bits()}</li>
+ *     <li>{@link #isVector()}</li>
+ *     <li>{@link #isIdentical(ConstMatrix, double)}</li>
+ *     <li>{@link #hasUncountable()}</li>
+ * </ul>
+ *
+ * <h3>Converting and reshaping</h3>
+ * <ul>
+ *     <li>{@link #convertToDense()}</li>
+ *     <li>{@link #convertToComplex()}</li>
+ *     <li>{@link #convertToSparse()}</li>
+ *     <li>{@link #reshape(int, int)}</li>
+ * </ul>
+ *
+ * <h3>Accessing the internal matrix</h3>
+ * <ul>
+ *     <li>{@link #getMatrix()}</li>
+ *     <li>{@link #getDDRM()}</li>
+ *     <li>{@link #getFDRM()}</li>
+ *     <li>{@link #getZDRM()}</li>
+ *     <li>{@link #getCDRM()}</li>
+ *     <li>{@link #getDSCC()}</li>
+ *     <li>{@link #getFSCC()}</li>
+ * </ul>
+ *
+ * <h3>Loading and saving</h3>
+ * <ul>
+ *     <li>{@link #loadCSV(String)}</li>
+ *     <li>{@link #saveToFileCSV(String)}</li>
+ *     <li>{@link #saveToMatrixMarket(String)}</li>
+ * </ul>
+ *
+ * <h3>Miscellaneous</h3>
+ * <ul>
+ *     <li>{@link #iterator(boolean, int, int, int, int)}</li>
+ *     <li>{@link #getIndex(int, int)}</li>
+ *     <li>{@link #isInBounds(int, int)}</li>
+ *     <li>{@link #equation(String, Object...)}</li>
+ *     <li>{@link #toString()}</li>
+ *     <li>{@link #toArray2()}</li>
+ *     <li>{@link #print()}</li>
+ *     <li>{@link #print(String)}</li>
+ *     <li>{@link #printDimensions()}</li>
+ * </ul>
  *
  * @author Peter Abeles
  */

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -173,6 +173,8 @@ import java.util.concurrent.ThreadLocalRandom;
  *     <td>Get the real component of the {@code i,j}<sup>th</sup> entry.</td></tr>
  *     <tr><td>{@link #getImaginary(int, int)}</td>
  *     <td>Get the imaginary component of the {@code i,j}<sup>th</sup> entry.</td></tr>
+ *     <tr><td>{@link #getImag(int, int)}</td>
+ *     <td>Alias for {@link #getImaginary(int, int)}</td></tr>
  *     <tr><td>{@link #getRow(int)}</td>
  *     <td>Get the {@code i}<sup>th</sup> row.</td></tr>
  *     <tr><td>{@link #getColumn(int)}</td>
@@ -253,6 +255,8 @@ import java.util.concurrent.ThreadLocalRandom;
  *     <td>Get the real component of each entry.</td></tr>
  *     <tr><td>{@link #imaginary()}</td>
  *     <td>Get the imaginary component of each entry.</td></tr>
+ *     <tr><td>{@link #imag()}</td>
+ *     <td>Alias for {@link #imaginary()}.</td></tr>
  *     <tr><td>{@link #magnitude()}</td>
  *     <td>Get the imaginary component of each entry.</td></tr>
  *     <tr><td>{@link #transpose()}</td>
@@ -350,6 +354,8 @@ import java.util.concurrent.ThreadLocalRandom;
  *     <td>Get the number of rows.</td></tr>
  *     <tr><td>{@link #getNumCols()}</td>
  *     <td>Get the number of columns.</td></tr>
+ *     <tr><td>{@link #getNumElements()}</td>
+ *     <td>Get the number of elements.</td></tr>
  *     <tr><td>{@link #bits()}</td>
  *     <td>Get the size of the internal array elements (32 or 64).</td></tr>
  *     <tr><td>{@link #isVector()}</td>

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -86,195 +86,345 @@ import java.util.concurrent.ThreadLocalRandom;
  * </p>
  *
  * <h3>Creating matrices</h3>
- * <ul>
- *     <li>{@link #SimpleMatrix()}</li>
- *     <li>{@link #SimpleMatrix(double[])}</li>
- *     <li>{@link #SimpleMatrix(double[][])}</li>
- *     <li>{@link #SimpleMatrix(float[])}</li>
- *     <li>{@link #SimpleMatrix(float[][])}</li>
- *     <li>{@link #SimpleMatrix(int, int)}</li>
- *     <li>{@link #SimpleMatrix(int, int, boolean, double...)}</li>
- *     <li>{@link #SimpleMatrix(int, int, boolean, float...)}</li>
- *     <li>{@link #SimpleMatrix(int, int, Class)}</li>
- *     <li>{@link #SimpleMatrix(int, int, MatrixType)}</li>
- *     <li>{@link #SimpleMatrix(Matrix)}</li>
- *     <li>{@link #SimpleMatrix(SimpleMatrix)}</li>
- *     <li>{@link #wrap(Matrix)}</li>
- *     <li>{@link #filled(int, int, double)}</li>
- *     <li>{@link #ones(int, int)}</li>
- *     <li>{@link #diag(double...)}</li>
- *     <li>{@link #diag(Class, double...)}</li>
- *     <li>{@link #identity(int)}</li>
- *     <li>{@link #identity(int, Class)}</li>
- *     <li>{@link #random(int, int)}</li>
- *     <li>{@link #random_DDRM(int, int, double, double, Random)}</li>
- *     <li>{@link #random_DDRM(int, int)}</li>
- *     <li>{@link #random_FDRM(int, int, float, float, Random)}</li>
- *     <li>{@link #random_FDRM(int, int)}</li>
- *     <li>{@link #random_ZDRM(int, int, double, double, Random)}</li>
- *     <li>{@link #random_ZDRM(int, int)}</li>
- *     <li>{@link #random_CDRM(int, int, float, float, Random)}</li>
- *     <li>{@link #random_CDRM(int, int)}</li>
- *     <li>{@link #randomNormal(SimpleMatrix, Random)}</li>
- *     <li>{@link #createLike()}</li>
- *     <li>{@link #copy()}</li>
- * </ul>
- *
- * <ul>
- *     <li>{@link #createLike()}</li>
- *     <li>{@link #copy()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #SimpleMatrix(int, int, Class)}</td>
+ *     <td>Create a matrix filled with zeros with the specified internal type.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(int, int, MatrixType)}</td>
+ *     <td>Create a matrix filled with zeros with the specified internal matrix type.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(int, int)}</td>
+ *     <td>Create a matrix filled with zeros.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(int, int, boolean, double...)}</td>
+ *     <td>Create a matrix with the provided double values, in either row-major or column-major order.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(int, int, boolean, float...)}</td>
+ *     <td>Create a matrix with the provided float values, in either row-major or column-major order.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(double[][])}</td>
+ *     <td>Create a matrix from a 2D double array.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(float[][])}</td>
+ *     <td>Create a matrix from a 2D float array.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(double[])}</td>
+ *     <td>Create a column vector from a 1D double array.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(float[])}</td>
+ *     <td>Create a column vector from a 1D float array.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(Matrix)}</td>
+ *     <td>Create a matrix copying the provided Matrix.</td></tr>
+ *     <tr><td>{@link #SimpleMatrix(SimpleMatrix)}</td>
+ *     <td>Create a matrix copying the provided SimpleMatrix.</td></tr>
+ *     <tr><td>{@link #wrap(Matrix)}</td>
+ *     <td>Create a matrix wrapping the provided Matrix.</td></tr>
+ *     <tr><td>{@link #filled(int, int, double)}</td>
+ *     <td>Create a matrix filled with the specified value.</td></tr>
+ *     <tr><td>{@link #ones(int, int)}</td>
+ *     <td>Create a matrix filled with ones.</td></tr>
+ *     <tr><td>{@link #diag(double...)}</td>
+ *     <td>Create a diagonal matrix.</td></tr>
+ *     <tr><td>{@link #diag(Class, double...)}</td>
+ *     <td>Create a diagonal matrix with the specified internal type.</td></tr>
+ *     <tr><td>{@link #identity(int)}</td>
+ *     <td>Create an identity matrix.</td></tr>
+ *     <tr><td>{@link #identity(int, Class)}</td>
+ *     <td>Create an identity matrix with the specified internal type.</td></tr>
+ *     <tr><td>{@link #random(int, int)}</td>
+ *     <td>Create a random {@link DMatrixRMaj} with values drawn from a continuous uniform distribution on the
+ *         unit interval.</td></tr>
+ *     <tr><td>{@link #random_DDRM(int, int, double, double, Random)}</td>
+ *     <td>Create a random {@link DMatrixRMaj} with values drawn from a continuous uniform distribution using the
+ *         provided random number generator.</td></tr>
+ *     <tr><td>{@link #random_DDRM(int, int)}</td>
+ *     <td>Create a random {@link DMatrixRMaj} with values drawn from a continuous uniform distribution on the
+ *         unit interval.</td></tr>
+ *     <tr><td>{@link #random_FDRM(int, int, float, float, Random)}</td>
+ *     <td>Create a random {@link FMatrixRMaj} with values drawn from a continuous uniform distribution using the
+ *         provided random number generator.</td></tr>
+ *     <tr><td>{@link #random_FDRM(int, int)}</td>
+ *     <td>Create a random {@link FMatrixRMaj} with values drawn from a continuous uniform distribution on the
+ *         unit interval.</td></tr>
+ *     <tr><td>{@link #random_ZDRM(int, int, double, double, Random)}</td>
+ *     <td>Create a random {@link ZMatrixRMaj} with values drawn from a continuous uniform distribution using the
+ *         provided random number generator.</td></tr>
+ *     <tr><td>{@link #random_ZDRM(int, int)}</td>
+ *     <td>Create a random {@link ZMatrixRMaj} with values drawn from a continuous uniform distribution on the
+ *         unit interval.</td></tr>
+ *     <tr><td>{@link #random_CDRM(int, int, float, float, Random)}</td>
+ *     <td>Create a random {@link CMatrixRMaj} with values drawn from a continuous uniform distribution using the
+ *         provided random number generator.</td></tr>
+ *     <tr><td>{@link #random_CDRM(int, int)}</td>
+ *     <td>Create a random {@link CMatrixRMaj} with values drawn from a continuous uniform distribution on the
+ *         unit interval.</td></tr>
+ *     <tr><td>{@link #randomNormal(SimpleMatrix, Random)}</td>
+ *     <td>Create a random vector drawn from a multivariate normal distribution
+ *         with the specified covariance.</td></tr>
+ *     <tr><td>{@link #createLike()}</td>
+ *     <td>Create a matrix with the same shape and internal type as this matrix.</td></tr>
+ *     <tr><td>{@link #copy()}</td>
+ *     <td>Create a copy of this matrix.</td></tr>
+ * </table>
  *
  * <h3>Getting elements, rows and columns</h3>
- * <ul>
- *     <li>{@link #get(int)}</li>
- *     <li>{@link #get(int, int)}</li>
- *     <li>{@link #get(int, int, Complex_F64)}</li>
- *     <li>{@link #getReal(int, int)}</li>
- *     <li>{@link #getImaginary(int, int)}</li>
- *     <li>{@link #getRow(int)} (int)}</li>
- *     <li>{@link #getColumn(int)}</li>
- *     <li>{@link #rows(int, int)} (int)}</li>
- *     <li>{@link #cols(int, int)}</li>
- *     <li>{@link #extractVector(boolean, int)}</li>
- *     <li>{@link #extractMatrix(int, int, int, int)}</li>
- *     <li>{@link #diag()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #get(int)}</td>
+ *     <td>Get the value of the {@code i}<sup>th</sup> entry in row-major order.</td></tr>
+ *     <tr><td>{@link #get(int, int)}</td>
+ *     <td>Get the value of the {@code i,j}<sup>th</sup> entry.</td></tr>
+ *     <tr><td>{@link #get(int, int, Complex_F64)}</td>
+ *     <td>Get the value of the {@code i,j}<sup>th</sup> entry as a complex number.</td></tr>
+ *     <tr><td>{@link #getReal(int, int)}</td>
+ *     <td>Get the real component of the {@code i,j}<sup>th</sup> entry.</td></tr>
+ *     <tr><td>{@link #getImaginary(int, int)}</td>
+ *     <td>Get the imaginary component of the {@code i,j}<sup>th</sup> entry.</td></tr>
+ *     <tr><td>{@link #getRow(int)}</td>
+ *     <td>Get the {@code i}<sup>th</sup> row.</td></tr>
+ *     <tr><td>{@link #getColumn(int)}</td>
+ *     <td>Get the {@code j}<sup>th</sup> column.</td></tr>
+ *     <tr><td>{@link #extractVector(boolean, int)}</td>
+ *     <td>Extract the specified row or column vector.</td></tr>
+ *     <tr><td>{@link #extractMatrix(int, int, int, int)}</td>
+ *     <td>Extract the specified submatrix.</td></tr>
+ *     <tr><td>{@link #rows(int, int)} (int)}</td>
+ *     <td>Extract the specified rows.</td></tr>
+ *     <tr><td>{@link #cols(int, int)}</td>
+ *     <td>Extract the specified columns.</td></tr>
+ *     <tr><td>{@link #diag()}</td>
+ *     <td>Extract the matrix diagonal, or construct a diagonal matrix from a vector.</td></tr>
+ * </table>
  *
  * <h3>Setting elements, rows and columns</h3>
- * <ul>
- *     <li>{@link #set(int, double)}</li>
- *     <li>{@link #set(int, int, double)}</li>
- *     <li>{@link #set(int, int, Complex_F64)}</li>
- *     <li>{@link #set(int, int, double, double)}</li>
- *     <li>{@link #setRow(int, int, double...)}</li>
- *     <li>{@link #setRow(int, ConstMatrix)}</li>
- *     <li>{@link #setColumn(int, int, double...)}</li>
- *     <li>{@link #setColumn(int, ConstMatrix)}</li>
- *     <li>{@link #setTo(SimpleBase)}</li>
- *     <li>{@link #insertIntoThis(int, int, SimpleBase)}</li>
- *     <li>{@link #fill(double)}</li>
- *     <li>{@link #fillComplex(double, double)}</li>
- *     <li>{@link #zero()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #set(int, double)}</td>
+ *     <td>Set the value of the {@code i}<sup>th</sup> entry in row-major order.</td></tr>
+ *     <tr><td>{@link #set(int, int, double)}</td>
+ *     <td>Set the value of the {@code i,j}<sup>th</sup> entry.</td></tr>
+ *     <tr><td>{@link #set(int, int, Complex_F64)}</td>
+ *     <td>Set the value of the {@code i,j}<sup>th</sup> entry as a complex number.</td></tr>
+ *     <tr><td>{@link #set(int, int, double, double)}</td>
+ *     <td>Set the real and imaginary components of the {@code i,j}<sup>th</sup> entry.</td></tr>
+ *     <tr><td>{@link #setRow(int, ConstMatrix)}</td>
+ *     <td>Set the {@code i}<sup>th</sup> row.</td></tr>
+ *     <tr><td>{@link #setRow(int, int, double...)}</td>
+ *     <td>Set the values in the {@code i}<sup>th</sup> row.</td></tr>
+ *     <tr><td>{@link #setColumn(int, ConstMatrix)}</td>
+ *     <td>Set the {@code j}<sup>th</sup> column.</td></tr>
+ *     <tr><td>{@link #setColumn(int, int, double...)}</td>
+ *     <td>Set the values in the {@code j}<sup>th</sup> column.</td></tr>
+ *     <tr><td>{@link #setTo(SimpleBase)}</td>
+ *     <td>Set the elements of this matrix to be equal to elements from another matrix.</td></tr>
+ *     <tr><td>{@link #insertIntoThis(int, int, SimpleBase)}</td>
+ *     <td>Insert values from another matrix, starting in position {@code i,j}.</td></tr>
+ *     <tr><td>{@link #fill(double)}</td>
+ *     <td>Set all elements of this matrix to be equal to specified value.</td></tr>
+ *     <tr><td>{@link #fillComplex(double, double)}</td>
+ *     <td>Set all elements of this matrix to be equal to specified complex value.</td></tr>
+ *     <tr><td>{@link #zero()}</td>
+ *     <td>Set all elements of this matrix to zero.</td></tr>
+ * </table>
  *
- * <h3>Matrix arithmetic</h3>
- * <ul>
- *     <li>{@link #plus(double)}</li>
- *     <li>{@link #plusComplex(double, double)}</li>
- *     <li>{@link #plus(ConstMatrix)}</li>
- *     <li>{@link #plus(double, ConstMatrix)}</li>
- *     <li>{@link #minus(double)}</li>
- *     <li>{@link #minusComplex(double, double)}</li>
- *     <li>{@link #minus(ConstMatrix)}</li>
- *     <li>{@link #scale(double)}</li>
- *     <li>{@link #scaleComplex(double, double)}</li>
- *     <li>{@link #mult(ConstMatrix)}</li>
- *     <li>{@link #dot(ConstMatrix)}</li>
- *     <li>{@link #divide(double)}</li>
- *     <li>{@link #negative()}</li>
- *     <li>{@link #real()}</li>
- *     <li>{@link #imaginary()}</li>
- *     <li>{@link #magnitude()}</li>
- *     <li>{@link #transpose()}</li>
- *     <li>{@link #transposeConjugate()}</li>
- * </ul>
+ * <h3>Basic operations</h3>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #plus(double)}</td>
+ *     <td>Add a scalar value.</td></tr>
+ *     <tr><td>{@link #plusComplex(double, double)}</td>
+ *     <td>Add a complex scalar value.</td></tr>
+ *     <tr><td>{@link #plus(ConstMatrix)}</td>
+ *     <td>Add another matrix.</td></tr>
+ *     <tr><td>{@link #plus(double, ConstMatrix)}</td>
+ *     <td>Add another matrix, first applying the specified scale factor.</td></tr>
+ *     <tr><td>{@link #minus(double)}</td>
+ *     <td>Subtract a scalar value.</td></tr>
+ *     <tr><td>{@link #minusComplex(double, double)}</td>
+ *     <td>Subtract a complex scalar value.</td></tr>
+ *     <tr><td>{@link #minus(ConstMatrix)}</td>
+ *     <td>Subtract another matrix.</td></tr>
+ *     <tr><td>{@link #scale(double)}</td>
+ *     <td>Multiply by a scalar value.</td></tr>
+ *     <tr><td>{@link #scaleComplex(double, double)}</td>
+ *     <td>Multiply by a complex scalar value.</td></tr>
+ *     <tr><td>{@link #divide(double)}</td>
+ *     <td>Divided by a scalar value.</td></tr>
+ *     <tr><td>{@link #mult(ConstMatrix)}</td>
+ *     <td>Multiply with another matrix.</td></tr>
+ *     <tr><td>{@link #dot(ConstMatrix)}</td>
+ *     <td>Calculate the dot product with another vector.</td></tr>
+ *     <tr><td>{@link #negative()}</td>
+ *     <td>Get the negative of each entry.</td></tr>
+ *     <tr><td>{@link #real()}</td>
+ *     <td>Get the real component of each entry.</td></tr>
+ *     <tr><td>{@link #imaginary()}</td>
+ *     <td>Get the imaginary component of each entry.</td></tr>
+ *     <tr><td>{@link #magnitude()}</td>
+ *     <td>Get the imaginary component of each entry.</td></tr>
+ *     <tr><td>{@link #transpose()}</td>
+ *     <td>Get the transpose.</td></tr>
+ *     <tr><td>{@link #transposeConjugate()}</td>
+ *     <td>Get the conjugate transpose.</td></tr>
+ *     <tr><td>{@link #equation(String, Object...)}</td>
+ *     <td>Perform an equation in place on the matrix.</td></tr>
+ * </table>
  *
  * <h3>Elementwise operations</h3>
- * <ul>
- *     <li>{@link #elementMult(ConstMatrix)}</li>
- *     <li>{@link #elementDiv(ConstMatrix)}</li>
- *     <li>{@link #elementPower(double)}</li>
- *     <li>{@link #elementPower(ConstMatrix)}</li>
- *     <li>{@link #elementExp()}</li>
- *     <li>{@link #elementLog()}</li>
- *     <li>{@link #elementOp(SimpleOperations.ElementOpReal)}</li>
- *     <li>{@link #elementOp(SimpleOperations.ElementOpComplex)}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #elementMult(ConstMatrix)}</td>
+ *     <td>Perform element by element multiplication with another matrix.</td></tr>
+ *     <tr><td>{@link #elementDiv(ConstMatrix)}</td>
+ *     <td>Perform element by element division with another matrix.</td></tr>
+ *     <tr><td>{@link #elementPower(double)}</td>
+ *     <td>Raise each entry to the specified power.</td></tr>
+ *     <tr><td>{@link #elementPower(ConstMatrix)}</td>
+ *     <td>Raise each entry to the corresponding power in another matrix.</td></tr>
+ *     <tr><td>{@link #elementExp()}</td>
+ *     <td>Compute the exponent of each entry.</td></tr>
+ *     <tr><td>{@link #elementLog()}</td>
+ *     <td>Compute the logarithm of each entry.</td></tr>
+ *     <tr><td>{@link #elementOp(SimpleOperations.ElementOpReal)}</td>
+ *     <td>Apply the specified real-valued function to each entry.</td></tr>
+ *     <tr><td>{@link #elementOp(SimpleOperations.ElementOpComplex)}</td>
+ *     <td>Apply the specified complex-valued function to each entry.</td></tr>
+ * </table>
  *
  * <h3>Aggregations</h3>
- * <ul>
- *     <li>{@link #elementSum()}</li>
- *     <li>{@link #elementSumComplex()}</li>
- *     <li>{@link #elementMax()}</li>
- *     <li>{@link #elementMaxAbs()}</li>
- *     <li>{@link #elementMin()}</li>
- *     <li>{@link #elementMinAbs()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #elementSum()}</td>
+ *     <td>Compute the sum of all elements of this matrix.</td></tr>
+ *     <tr><td>{@link #elementSumComplex()}</td>
+ *     <td>Compute the sum of all elements of a complex matrix.</td></tr>
+ *     <tr><td>{@link #elementMax()}</td>
+ *     <td>Compute the maximum of all elements of this matrix.</td></tr>
+ *     <tr><td>{@link #elementMaxAbs()}</td>
+ *     <td>Compute the maximum absolute value of all elements of this matrix.</td></tr>
+ *     <tr><td>{@link #elementMin()}</td>
+ *     <td>Compute the minimum of all elements of this matrix.</td></tr>
+ *     <tr><td>{@link #elementMinAbs()}</td>
+ *     <td>Compute the minimum absolute value of all elements of this matrix.</td></tr>
+ * </table>
  *
  * <h3>Linear algebra</h3>
- * <ul>
- *     <li>{@link #solve(ConstMatrix)}</li>
- *     <li>{@link #invert()}</li>
- *     <li>{@link #pseudoInverse()}</li>
- *     <li>{@link #kron(ConstMatrix)}</li>
- *     <li>{@link #determinant()}</li>
- *     <li>{@link #determinantComplex()}</li>
- *     <li>{@link #trace()}</li>
- *     <li>{@link #traceComplex()}</li>
- *     <li>{@link #normF()}</li>
- *     <li>{@link #conditionP2()}</li>
- *     <li>{@link #eig()}</li>
- *     <li>{@link #svd()}</li>
- *     <li>{@link #svd(boolean)}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #solve(ConstMatrix)}</td>
+ *     <td>Solve the equation {@code Ax = b}.</td></tr>
+ *     <tr><td>{@link #conditionP2()}</td>
+ *     <td>Compute the matrix condition number.</td></tr>
+ *     <tr><td>{@link #invert()}</td>
+ *     <td>Compute the matrix inverse.</td></tr>
+ *     <tr><td>{@link #pseudoInverse()}</td>
+ *     <td>Compute the Moore-Penrose pseudo-inverse.</td></tr>
+ *     <tr><td>{@link #determinant()}</td>
+ *     <td>Compute the determinant.</td></tr>
+ *     <tr><td>{@link #determinantComplex()}</td>
+ *     <td>Compute the determinant of a complex matrix.</td></tr>
+ *     <tr><td>{@link #trace()}</td>
+ *     <td>Compute the trace.</td></tr>
+ *     <tr><td>{@link #traceComplex()}</td>
+ *     <td>Compute the trace of a complex matrix.</td></tr>
+ *     <tr><td>{@link #normF()}</td>
+ *     <td>Compute the Frobenius norm.</td></tr>
+ *     <tr><td>{@link #eig()}</td>
+ *     <td>Compute the eigenvalue decomposition.</td></tr>
+ *     <tr><td>{@link #svd()}</td>
+ *     <td>Compute the singular value decomposition.</td></tr>
+ *     <tr><td>{@link #svd(boolean)}</td>
+ *     <td>Compute the singular value decomposition in compact or full format.</td></tr>
+ * </table>
  *
  * <h3>Combining matrices</h3>
- * <ul>
- *     <li>{@link #combine(int, int, ConstMatrix)}</li>
- *     <li>{@link #concatRows(ConstMatrix[])}</li>
- *     <li>{@link #concatColumns(ConstMatrix[])}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #combine(int, int, ConstMatrix)}</td>
+ *     <td>Combine with another matrix.</td></tr>
+ *     <tr><td>{@link #concatRows(ConstMatrix...)}</td>
+ *     <td>Concatenate vertically with one or more other matrices.</td></tr>
+ *     <tr><td>{@link #concatColumns(ConstMatrix...)}</td>
+ *     <td>Concatenate horizontally with one or more other matrices.</td></tr>
+ *     <tr><td>{@link #kron(ConstMatrix)}</td>
+ *     <td>Compute the Kronecker product with another matrix.</td></tr>
+ * </table>
  *
  * <h3>Matrix properties</h3>
- * <ul>
- *     <li>{@link #getNumRows()}</li>
- *     <li>{@link #getNumCols()}</li>
- *     <li>{@link #getType()}</li>
- *     <li>{@link #bits()}</li>
- *     <li>{@link #isVector()}</li>
- *     <li>{@link #isIdentical(ConstMatrix, double)}</li>
- *     <li>{@link #hasUncountable()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #getNumRows()}</td>
+ *     <td>Get the number of rows.</td></tr>
+ *     <tr><td>{@link #getNumCols()}</td>
+ *     <td>Get the number of columns.</td></tr>
+ *     <tr><td>{@link #bits()}</td>
+ *     <td>Get the size of the internal array elements (32 or 64).</td></tr>
+ *     <tr><td>{@link #isVector()}</td>
+ *     <td>Check if this matrix is a vector.</td></tr>
+ *     <tr><td>{@link #isIdentical(ConstMatrix, double)}</td>
+ *     <td>Check if this matrix is the same as another matrix, up to the specified tolerance.</td></tr>
+ *     <tr><td>{@link #hasUncountable()}</td>
+ *     <td>Check if any of the matrix elements are NaN or infinite.</td></tr>
+ * </table>
  *
  * <h3>Converting and reshaping</h3>
- * <ul>
- *     <li>{@link #convertToDense()}</li>
- *     <li>{@link #convertToComplex()}</li>
- *     <li>{@link #convertToSparse()}</li>
- *     <li>{@link #reshape(int, int)}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #convertToComplex()}</td>
+ *     <td>Convert to a complex matrix.</td></tr>
+ *     <tr><td>{@link #convertToDense()}</td>
+ *     <td>Convert to a dense matrix.</td></tr>
+ *     <tr><td>{@link #convertToSparse()}</td>
+ *     <td>Convert to a sparse matrix.</td></tr>
+ *     <tr><td>{@link #reshape(int, int)}</td>
+ *     <td>Change the number of rows and columns.</td></tr>
+ * </table>
  *
  * <h3>Accessing the internal matrix</h3>
- * <ul>
- *     <li>{@link #getMatrix()}</li>
- *     <li>{@link #getDDRM()}</li>
- *     <li>{@link #getFDRM()}</li>
- *     <li>{@link #getZDRM()}</li>
- *     <li>{@link #getCDRM()}</li>
- *     <li>{@link #getDSCC()}</li>
- *     <li>{@link #getFSCC()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #getType()}</td>
+ *     <td>Get the type of the wrapped matrix.</td></tr>
+ *     <tr><td>{@link #getMatrix()}</td>
+ *     <td>Get the wrapped matrix.</td></tr>
+ *     <tr><td>{@link #getDDRM()}</td>
+ *     <td>Get the wrapped matrix as a {@link DMatrixRMaj}.</td></tr>
+ *     <tr><td>{@link #getFDRM()}</td>
+ *     <td>Get the wrapped matrix as a {@link FMatrixRMaj}.</td></tr>
+ *     <tr><td>{@link #getZDRM()}</td>
+ *     <td>Get the wrapped matrix as a {@link ZMatrixRMaj}.</td></tr>
+ *     <tr><td>{@link #getCDRM()}</td>
+ *     <td>Get the wrapped matrix as a {@link CMatrixRMaj}.</td></tr>
+ *     <tr><td>{@link #getDSCC()}</td>
+ *     <td>Get the wrapped matrix as a {@link DMatrixSparseCSC}.</td></tr>
+ *     <tr><td>{@link #getFSCC()}</td>
+ *     <td>Get the wrapped matrix as a {@link FMatrixSparseCSC}.</td></tr>
+ * </table>
  *
  * <h3>Loading and saving</h3>
- * <ul>
- *     <li>{@link #loadCSV(String)}</li>
- *     <li>{@link #saveToFileCSV(String)}</li>
- *     <li>{@link #saveToMatrixMarket(String)}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #loadCSV(String)}</td>
+ *     <td>Load a matrix from a CSV file.</td></tr>
+ *     <tr><td>{@link #saveToFileCSV(String)}</td>
+ *     <td>Save this matrix to a CSV file.</td></tr>
+ *     <tr><td>{@link #saveToMatrixMarket(String)}</td>
+ *     <td>Save this matrix in matrix market format.</td></tr>
+ * </table>
  *
  * <h3>Miscellaneous</h3>
- * <ul>
- *     <li>{@link #iterator(boolean, int, int, int, int)}</li>
- *     <li>{@link #getIndex(int, int)}</li>
- *     <li>{@link #isInBounds(int, int)}</li>
- *     <li>{@link #equation(String, Object...)}</li>
- *     <li>{@link #toString()}</li>
- *     <li>{@link #toArray2()}</li>
- *     <li>{@link #print()}</li>
- *     <li>{@link #print(String)}</li>
- *     <li>{@link #printDimensions()}</li>
- * </ul>
+ * <table>
+ *     <tr><th>Method</th><th>Description</th></tr>
+ *     <tr><td>{@link #iterator(boolean, int, int, int, int)}</td>
+ *     <td>Create an iterator for traversing a submatrix.</td></tr>
+ *     <tr><td>{@link #getIndex(int, int)}</td>
+ *     <td>Get the row-major index corresponding to {@code i,j}.</td></tr>
+ *     <tr><td>{@link #isInBounds(int, int)}</td>
+ *     <td>Check if the indices {@code i,j} are in bounds.</td></tr>
+ *     <tr><td>{@link #toString()}</td>
+ *     <td>Get the string representation of the matrix.</td></tr>
+ *     <tr><td>{@link #toArray2()}</td>
+ *     <td>Convert the matrix to a 2D array of doubles.</td></tr>
+ *     <tr><td>{@link #print()}</td>
+ *     <td>Print the matrix to standard out.</td></tr>
+ *     <tr><td>{@link #print(String)}</td>
+ *     <td>Print the matrix to standard out using the specified floating point format.</td></tr>
+ *     <tr><td>{@link #printDimensions()}</td>
+ *     <td>Print the number of rows and columns.</td></tr>
+ * </table>
  *
  * @author Peter Abeles
  */
@@ -408,7 +558,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a new matrix that is initially set to zero with the specified dimensions and type.
+     * Creates a new matrix that is initially set to zero with the specified dimensions and matrix type.
      *
      * @param numRows The number of rows in the matrix.
      * @param numCols The number of columns in the matrix.
@@ -462,10 +612,10 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     protected SimpleMatrix() {}
 
     /**
-     * Creates a new SimpleMatrix with the specified DMatrixRMaj used as its internal matrix. This means
-     * that the reference is saved and calls made to the returned SimpleMatrix will modify the passed in DMatrixRMaj.
+     * Creates a new SimpleMatrix with the specified Matrix used as its internal matrix. This means
+     * that the reference is saved and calls made to the returned SimpleMatrix will modify the passed in Matrix.
      *
-     * @param internalMat The internal DMatrixRMaj of the returned SimpleMatrix. Will be modified.
+     * @param internalMat The internal Matrix of the returned SimpleMatrix. Will be modified.
      */
     public static SimpleMatrix wrap( Matrix internalMat ) {
         var ret = new SimpleMatrix();
@@ -557,7 +707,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from minValue (inclusive) to
+     * Creates a random matrix with values drawn from the continuous uniform distribution from minValue (inclusive) to
      * maxValue (exclusive). This will wrap a {@link DMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
@@ -575,7 +725,8 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     * Creates a random matrix with values drawn from the continuous uniform distribution from 0.0 (inclusive) to
+     * 1.0 (exclusive).
      *
      * @param numRows The number of rows in the new matrix
      * @param numCols The number of columns in the new matrix
@@ -586,7 +737,8 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
+     * Creates a random matrix with values drawn from the continuous uniform distribution from 0.0 (inclusive) to
+     * 1.0 (exclusive).
      * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link DMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
@@ -597,7 +749,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from minValue (inclusive) to
+     * Creates a random matrix with values drawn from the continuous uniform distribution from minValue (inclusive) to
      * maxValue (exclusive). This will wrap a {@link FMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
@@ -615,8 +767,9 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
-     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link FMatrixRMaj}.
+     * Creates a random matrix with values drawn from the continuous uniform distribution from 0.0 (inclusive) to
+     * 1.0 (exclusive). The random number generator is {@link ThreadLocalRandom#current()}.
+     * This will wrap a {@link FMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
      * @param numCols The number of columns in the new matrix
@@ -626,7 +779,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with real and complex components drawn from the uniform distribution from
+     * Creates a random matrix with real and complex components drawn from the continuous uniform distribution from
      * minValue (inclusive) to maxValue (exclusive). This will wrap a {@link ZMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
@@ -644,8 +797,9 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
-     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link ZMatrixRMaj}.
+     * Creates a random matrix with values drawn from the continuous uniform distribution from 0.0 (inclusive) to
+     * 1.0 (exclusive). The random number generator is {@link ThreadLocalRandom#current()}.
+     * This will wrap a {@link ZMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
      * @param numCols The number of columns in the new matrix
@@ -655,7 +809,7 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with real and complex components drawn from the uniform distribution from
+     * Creates a random matrix with real and complex components drawn from the continuous uniform distribution from
      * minValue (inclusive) to maxValue (exclusive). This will wrap a {@link CMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
@@ -673,8 +827,9 @@ public class SimpleMatrix extends SimpleBase<SimpleMatrix> {
     }
 
     /**
-     * Creates a random matrix with values drawn from the uniform distribution from 0.0 (inclusive) to 1.0 (exclusive).
-     * The random number generator is {@link ThreadLocalRandom#current()}. This will wrap a {@link CMatrixRMaj}.
+     * Creates a random matrix with values drawn from the continuous uniform distribution from 0.0 (inclusive) to
+     * 1.0 (exclusive). The random number generator is {@link ThreadLocalRandom#current()}.
+     * This will wrap a {@link CMatrixRMaj}.
      *
      * @param numRows The number of rows in the new matrix
      * @param numCols The number of columns in the new matrix

--- a/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleMatrix.java
@@ -181,7 +181,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *     <td>Extract the specified row or column vector.</td></tr>
  *     <tr><td>{@link #extractMatrix(int, int, int, int)}</td>
  *     <td>Extract the specified submatrix.</td></tr>
- *     <tr><td>{@link #rows(int, int)} (int)}</td>
+ *     <tr><td>{@link #rows(int, int)}</td>
  *     <td>Extract the specified rows.</td></tr>
  *     <tr><td>{@link #cols(int, int)}</td>
  *     <td>Extract the specified columns.</td></tr>


### PR DESCRIPTION
This PR contains various documentation additions/changes for `SimpleMatrix`:

- The main addition is a set of tables listing the methods in `SimpleMatrix`/`SimpleBase` with brief descriptions. Unlike the javadoc summary table, this groups and sorts methods according to functionality. Given that `SimpleMatrix`/`SimpleBase` combined have ~100 methods, it can be difficult to find the method you need when looking through an ungrouped alphabetical list.

- Added missing javadoc for a few methods.

- References to an internal `DMatrixRMaj` have been replaced by references to an internal matrix where appropriate.

- Replaced "a.k.a." by "or" to avoid the javadoc summary cutting off early (it assumes a period and space terminates the first sentence).