### PR TITLE
Feature/Add DMatrixRMaj#get2DData interface

### DIFF
--- a/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *

--- a/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
+++ b/main/ejml-core/src/org/ejml/data/DMatrixRMaj.java
@@ -374,4 +374,14 @@ public class DMatrixRMaj extends DMatrix1Row {
     public void set( double[][] input ) {
         DConvertArrays.convert(input, this);
     }
+
+    /**
+     * Export this matrix using a 2D array representation.
+     *
+     * @return 2D representation of the matrix
+     * @see DMatrixD1#getData() to get a 1D array representation
+     */
+    public double[][] get2DData() {
+        return DConvertArrays.convert(this);
+    }
 }

--- a/main/ejml-core/src/org/ejml/ops/DConvertArrays.java
+++ b/main/ejml-core/src/org/ejml/ops/DConvertArrays.java
@@ -58,6 +58,24 @@ public class DConvertArrays {
         return dst;
     }
 
+    /**
+     * Convert a {@link DMatrixRMaj} to a two-dimensional array,
+     * given DMatrixRMaj can take a double[][] as input to constructor
+     *
+     * @param src is an input DMatrixRMaj
+     * @return a 2D array contains the same elements as the input matrix
+     */
+    public static double[][] convert( DMatrixRMaj src ) {
+        double[][] array = new double[src.numRows][src.numCols];
+        for (int row = 0; row < src.numRows; row++) {
+            for (int column = 0; column < src.numCols; column++) {
+                array[row][column] = src.get(row, column);
+            }
+        }
+
+        return array;
+    }
+
 //    public static DMatrixSparseCSC convert(double[][]src , @Nullable DMatrixSparseCSC dst ) {
 //        int rows = src.length;
 //        if( rows == 0 )

--- a/main/ejml-core/src/org/ejml/ops/DConvertArrays.java
+++ b/main/ejml-core/src/org/ejml/ops/DConvertArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Peter Abeles. All Rights Reserved.
+ * Copyright (c) 2023, Peter Abeles. All Rights Reserved.
  *
  * This file is part of Efficient Java Matrix Library (EJML).
  *
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ejml.ops;
 
 import org.ejml.UtilEjml;
@@ -69,7 +68,7 @@ public class DConvertArrays {
         double[][] array = new double[src.numRows][src.numCols];
         for (int row = 0; row < src.numRows; row++) {
             for (int column = 0; column < src.numCols; column++) {
-                array[row][column] = src.get(row, column);
+                array[row][column] = src.unsafe_get(row, column);
             }
         }
 

--- a/main/ejml-core/test/org/ejml/data/TestDMatrixRMaj.java
+++ b/main/ejml-core/test/org/ejml/data/TestDMatrixRMaj.java
@@ -204,4 +204,15 @@ public class TestDMatrixRMaj extends EjmlStandardJUnit {
             assertTrue(Math.abs(mat.data[i] - orig.data[i]) > UtilEjml.TEST_F64);
         }
     }
+
+    @Test void get2DData() {
+        double[][] expected = {{0, 1}, {2, 3}};
+        double[][] actual = new DMatrixRMaj(expected).get2DData();
+
+        assertArrayEquals(expected, actual);
+        assertEquals(0,actual[0][0], UtilEjml.TEST_F64);
+        assertEquals(1,actual[0][1], UtilEjml.TEST_F64);
+        assertEquals(2,actual[1][0], UtilEjml.TEST_F64);
+        assertEquals(3,actual[1][1], UtilEjml.TEST_F64);
+    }
 }

--- a/main/ejml-core/test/org/ejml/data/TestDMatrixRMaj.java
+++ b/main/ejml-core/test/org/ejml/data/TestDMatrixRMaj.java
@@ -210,9 +210,9 @@ public class TestDMatrixRMaj extends EjmlStandardJUnit {
         double[][] actual = new DMatrixRMaj(expected).get2DData();
 
         assertArrayEquals(expected, actual);
-        assertEquals(0,actual[0][0], UtilEjml.TEST_F64);
-        assertEquals(1,actual[0][1], UtilEjml.TEST_F64);
-        assertEquals(2,actual[1][0], UtilEjml.TEST_F64);
-        assertEquals(3,actual[1][1], UtilEjml.TEST_F64);
+        assertEquals(0, actual[0][0], UtilEjml.TEST_F64);
+        assertEquals(1, actual[0][1], UtilEjml.TEST_F64);
+        assertEquals(2, actual[1][0], UtilEjml.TEST_F64);
+        assertEquals(3, actual[1][1], UtilEjml.TEST_F64);
     }
 }

--- a/main/ejml-core/test/org/ejml/ops/TestDConvertArrays.java
+++ b/main/ejml-core/test/org/ejml/ops/TestDConvertArrays.java
@@ -30,12 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestDConvertArrays extends EjmlStandardJUnit {
     @Test
     public void dd_to_ddrm() {
-        DMatrixRMaj m = DConvertArrays.convert(new double[][]{{0,1},{2,3}},(DMatrixRMaj)null);
+        DMatrixRMaj m = DConvertArrays.convert(new double[][]{{0, 1}, {2, 3}}, (DMatrixRMaj)null);
 
-        assertEquals(0,m.get(0,0), UtilEjml.TEST_F64);
-        assertEquals(1,m.get(0,1), UtilEjml.TEST_F64);
-        assertEquals(2,m.get(1,0), UtilEjml.TEST_F64);
-        assertEquals(3,m.get(1,1), UtilEjml.TEST_F64);
+        assertEquals(0, m.get(0, 0), UtilEjml.TEST_F64);
+        assertEquals(1, m.get(0, 1), UtilEjml.TEST_F64);
+        assertEquals(2, m.get(1, 0), UtilEjml.TEST_F64);
+        assertEquals(3, m.get(1, 1), UtilEjml.TEST_F64);
     }
 
     @Test
@@ -44,10 +44,10 @@ public class TestDConvertArrays extends EjmlStandardJUnit {
         double[][] dd = DConvertArrays.convert(new DMatrixRMaj(expected));
 
         assertArrayEquals(expected, dd);
-        assertEquals(0,dd[0][0], UtilEjml.TEST_F64);
-        assertEquals(1,dd[0][1], UtilEjml.TEST_F64);
-        assertEquals(2,dd[1][0], UtilEjml.TEST_F64);
-        assertEquals(3,dd[1][1], UtilEjml.TEST_F64);
+        assertEquals(0, dd[0][0], UtilEjml.TEST_F64);
+        assertEquals(1, dd[0][1], UtilEjml.TEST_F64);
+        assertEquals(2, dd[1][0], UtilEjml.TEST_F64);
+        assertEquals(3, dd[1][1], UtilEjml.TEST_F64);
     }
 
 //    @Test
@@ -65,11 +65,11 @@ public class TestDConvertArrays extends EjmlStandardJUnit {
 
     @Test
     public void dd_to_d4() {
-        DMatrix4 m = DConvertArrays.convert(new double[][]{{0,1,2,3}},(DMatrix4) null);
+        DMatrix4 m = DConvertArrays.convert(new double[][]{{0, 1, 2, 3}}, (DMatrix4)null);
 
-        assertEquals(0,m.a1, UtilEjml.TEST_F64);
-        assertEquals(1,m.a2, UtilEjml.TEST_F64);
-        assertEquals(2,m.a3, UtilEjml.TEST_F64);
-        assertEquals(3,m.a4, UtilEjml.TEST_F64);
+        assertEquals(0, m.a1, UtilEjml.TEST_F64);
+        assertEquals(1, m.a2, UtilEjml.TEST_F64);
+        assertEquals(2, m.a3, UtilEjml.TEST_F64);
+        assertEquals(3, m.a4, UtilEjml.TEST_F64);
     }
 }

--- a/main/ejml-core/test/org/ejml/ops/TestDConvertArrays.java
+++ b/main/ejml-core/test/org/ejml/ops/TestDConvertArrays.java
@@ -24,6 +24,7 @@ import org.ejml.data.DMatrix4;
 import org.ejml.data.DMatrixRMaj;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestDConvertArrays extends EjmlStandardJUnit {
@@ -35,6 +36,18 @@ public class TestDConvertArrays extends EjmlStandardJUnit {
         assertEquals(1,m.get(0,1), UtilEjml.TEST_F64);
         assertEquals(2,m.get(1,0), UtilEjml.TEST_F64);
         assertEquals(3,m.get(1,1), UtilEjml.TEST_F64);
+    }
+
+    @Test
+    public void ddrm_to_dd() {
+        double[][] expected = {{0, 1}, {2, 3}};
+        double[][] dd = DConvertArrays.convert(new DMatrixRMaj(expected));
+
+        assertArrayEquals(expected, dd);
+        assertEquals(0,dd[0][0], UtilEjml.TEST_F64);
+        assertEquals(1,dd[0][1], UtilEjml.TEST_F64);
+        assertEquals(2,dd[1][0], UtilEjml.TEST_F64);
+        assertEquals(3,dd[1][1], UtilEjml.TEST_F64);
     }
 
 //    @Test


### PR DESCRIPTION
Thank you for your contribution to the EJML project.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR is for Feature Request https://github.com/lessthanoptimal/ejml/issues/193. `DMatrixRMaj` can be converted from a double-dimensional array (a 2D array `doulbe[][]`) in one of its constructors. But, not the other way around. This new interface `DMatrixRMaj#get2DData` will make `DMatrixRMaj` easier to use. 

Before submitting this PR, please make sure:
- [x] Your code is covered by tests
- [x] You ran `./gradlew spotlessJavaApply`