### PR TITLE
SimpleEVD and SimpleSVD

### DIFF
--- a/main/ejml-simple/src/org/ejml/simple/SimpleEVD.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleEVD.java
@@ -43,14 +43,21 @@ public class SimpleEVD<T extends SimpleBase> {
     public SimpleEVD( Matrix mat ) {
         this.mat = mat;
 
-        switch (mat.getType()) {
-            case DDRM: eig = DecompositionFactory_DDRM.eig(mat.getNumCols(), true); break;
-            case FDRM: eig = DecompositionFactory_FDRM.eig(mat.getNumCols(), true); break;
-            default: throw new IllegalArgumentException("Matrix type not yet supported. " + mat.getType());
-        }
+        eig = createEigen(mat.getType());
+
+        if (eig.inputModified())
+            mat = mat.copy();
 
         if (!eig.decompose(mat))
             throw new RuntimeException("Eigenvalue Decomposition failed");
+    }
+
+    protected EigenDecomposition createEigen( MatrixType type ) {
+        return switch (type) {
+            case DDRM -> DecompositionFactory_DDRM.eig(mat.getNumCols(), true);
+            case FDRM -> DecompositionFactory_FDRM.eig(mat.getNumCols(), true);
+            default -> throw new IllegalArgumentException("Matrix type not yet supported. " + mat.getType());
+        };
     }
 
     /**
@@ -60,12 +67,12 @@ public class SimpleEVD<T extends SimpleBase> {
         List<Complex_F64> ret = new ArrayList<>();
 
         if (mat.getType().getBits() == 64) {
-            EigenDecomposition_F64 d = (EigenDecomposition_F64)eig;
+            var d = (EigenDecomposition_F64)eig;
             for (int i = 0; i < eig.getNumberOfEigenvalues(); i++) {
                 ret.add(d.getEigenvalue(i));
             }
         } else {
-            EigenDecomposition_F32 d = (EigenDecomposition_F32)eig;
+            var d = (EigenDecomposition_F32)eig;
             for (int i = 0; i < eig.getNumberOfEigenvalues(); i++) {
                 Complex_F32 c = d.getEigenvalue(i);
                 ret.add(new Complex_F64(c.real, c.imaginary));

--- a/main/ejml-simple/src/org/ejml/simple/SimpleSVD.java
+++ b/main/ejml-simple/src/org/ejml/simple/SimpleSVD.java
@@ -21,6 +21,7 @@ import org.ejml.UtilEjml;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.data.FMatrixRMaj;
 import org.ejml.data.Matrix;
+import org.ejml.data.MatrixType;
 import org.ejml.dense.row.SingularOps_DDRM;
 import org.ejml.dense.row.SingularOps_FDRM;
 import org.ejml.dense.row.factory.DecompositionFactory_DDRM;
@@ -45,7 +46,7 @@ import org.ejml.interfaces.decomposition.SingularValueDecomposition_F64;
  *
  * @author Peter Abeles
  */
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({"unchecked", "rawtypes", "NullAway.Init"})
 public class SimpleSVD<T extends SimpleBase> {
 
     private SingularValueDecomposition svd;
@@ -53,6 +54,7 @@ public class SimpleSVD<T extends SimpleBase> {
     private T W;
     private T V;
 
+    // Input matrix (unmodified)
     private Matrix mat;
     final boolean is64;
 
@@ -60,18 +62,26 @@ public class SimpleSVD<T extends SimpleBase> {
     double tol;
 
     public SimpleSVD( Matrix mat, boolean compact ) {
-        this.mat = mat;
         this.is64 = mat instanceof DMatrixRMaj;
-        if (is64) {
-            DMatrixRMaj m = (DMatrixRMaj)mat;
-            svd = DecompositionFactory_DDRM.svd(m.numRows, m.numCols, true, true, compact);
-        } else {
-            FMatrixRMaj m = (FMatrixRMaj)mat;
-            svd = DecompositionFactory_FDRM.svd(m.numRows, m.numCols, true, true, compact);
-        }
+        svd = createSvd(mat.getNumRows(), mat.getNumCols(), mat.getType(), compact);
 
-        if (!svd.decompose(mat))
+        this.mat = mat;
+
+        if (!svd.decompose(svd.inputModified() ? mat.copy() : mat))
             throw new RuntimeException("Decomposition failed");
+
+        extractDecomposition();
+    }
+
+    protected SingularValueDecomposition createSvd( int numRows, int numCols, MatrixType type, boolean compact ) {
+        return switch (type) {
+            case DDRM -> DecompositionFactory_DDRM.svd(numRows, numCols, true, true, compact);
+            case FDRM -> DecompositionFactory_FDRM.svd(numRows, numCols, true, true, compact);
+            default -> throw new IllegalArgumentException("Matrix type not yet supported. " + mat.getType());
+        };
+    }
+
+    protected void extractDecomposition() {
         U = (T)SimpleMatrix.wrap(svd.getU(null, false));
         W = (T)SimpleMatrix.wrap(svd.getW(null));
         V = (T)SimpleMatrix.wrap(svd.getV(null, false));

--- a/main/ejml-simple/test/org/ejml/simple/TestSimpleEVD.java
+++ b/main/ejml-simple/test/org/ejml/simple/TestSimpleEVD.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Peter Abeles. All Rights Reserved.
+ *
+ * This file is part of Efficient Java Matrix Library (EJML).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ejml.simple;
+
+import org.ejml.EjmlStandardJUnit;
+import org.ejml.data.Complex_F64;
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.data.Matrix;
+import org.ejml.data.MatrixType;
+import org.ejml.dense.row.MatrixFeatures_DDRM;
+import org.ejml.dense.row.RandomMatrices_DDRM;
+import org.ejml.interfaces.decomposition.EigenDecomposition;
+import org.ejml.interfaces.decomposition.EigenDecomposition_F64;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestSimpleEVD extends EjmlStandardJUnit {
+    // Verifies that the input is not modified
+    @Test void inputModified() {
+        DMatrixRMaj mat = RandomMatrices_DDRM.rectangle(5, 5, rand);
+        DMatrixRMaj original = mat.copy();
+
+        // Create a mock EVD that we know will modify the input
+        new SimpleEVD<>(mat) {
+            @Override protected EigenDecomposition createEigen( MatrixType type ) {
+                return new EigenDecomposition_F64() {
+                    @Override public Complex_F64 getEigenvalue( int index ) {return null; }
+                    @Override public int getNumberOfEigenvalues() { return 0; }
+                    @Override public Matrix getEigenVector( int index ) {return null;}
+                    @Override public boolean inputModified() {return true;}
+                    @Override public boolean decompose( Matrix orig ) {
+                        ((DMatrixRMaj)orig).set(0,0, 100);
+                        return true;
+                    }
+                };
+            }
+        };
+
+        assertTrue(MatrixFeatures_DDRM.isIdentical(mat, original, 0.0));
+    }
+}

--- a/main/ejml-simple/test/org/ejml/simple/TestSimpleSVD.java
+++ b/main/ejml-simple/test/org/ejml/simple/TestSimpleSVD.java
@@ -19,11 +19,50 @@
 package org.ejml.simple;
 
 import org.ejml.EjmlStandardJUnit;
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.data.Matrix;
+import org.ejml.data.MatrixType;
+import org.ejml.dense.row.MatrixFeatures_DDRM;
+import org.ejml.dense.row.RandomMatrices_DDRM;
+import org.ejml.interfaces.decomposition.SingularValueDecomposition;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestSimpleSVD extends EjmlStandardJUnit {
+    // Verifies that the input is not modified
+    @Test void inputModified() {
+        DMatrixRMaj mat = RandomMatrices_DDRM.rectangle(5, 5, rand);
+        DMatrixRMaj original = mat.copy();
+
+        // It will decompose. If not properly shielded it could modify the input
+        new SimpleSVD<>(mat, true) {
+            @Override
+            protected SingularValueDecomposition<DMatrixRMaj> createSvd( int numRows, int numCols, MatrixType type, boolean compact ) {
+                return new SingularValueDecomposition<>() {
+                    @Override public int numberOfSingularValues() {return 0;}
+                    @Override public boolean isCompact() { return false;}
+                    @Override public DMatrixRMaj getU( @Nullable DMatrixRMaj U, boolean transposed ) {return new DMatrixRMaj();}
+                    @Override public DMatrixRMaj getV( @Nullable DMatrixRMaj V, boolean transposed ) {return new DMatrixRMaj(); }
+                    @Override public DMatrixRMaj getW( @Nullable DMatrixRMaj W ) {return new DMatrixRMaj();}
+                    @Override public int numRows() {return 0;}
+                    @Override public int numCols() {return 0;}
+                    @Override public boolean inputModified() {return true;}
+                    @Override public boolean decompose( DMatrixRMaj orig ) {
+                        orig.set(0,0, 100);
+                        return true;
+                    }
+                };
+            }
+
+            @Override protected void extractDecomposition() {}
+        };
+
+        assertTrue(MatrixFeatures_DDRM.isIdentical(mat, original, 0.0));
+    }
+
     @Test void rank_case0() {
         for (int dimen = 1; dimen < 10; dimen++) {
             assertEquals(dimen, SimpleMatrix.identity(dimen).svd().rank());


### PR DESCRIPTION
- Correctly verify that input matrix are not modified
- If modified it will create a local copy to decompose
- Unit tests added
- Thanks @kasparthommen for reporting this issue

Thank you for your contribution to the EJML project.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please make sure:
- [x] Your code is covered by tests
- [x] You ran `./gradlew spotlessJavaApply`