### PR TITLE
MapPrintFormat

### DIFF
--- a/main/ejml-core/src/org/ejml/MapPrintFormat.java
+++ b/main/ejml-core/src/org/ejml/MapPrintFormat.java
@@ -21,7 +21,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Function;
+
 /// Describes how to format an object when it's converted into a map style string.
+///
+/// All provided default formatting is on a single line. Making it look like with indication is difficult and can't
+/// be done in this framework.
 public class MapPrintFormat extends PrintFormat {
     /// Default valued used in toString and other location. Modifying this will modify the formatting in many locations
     /// Only the end user should be tweaking this and not any library and its subject to change.
@@ -41,7 +46,7 @@ public class MapPrintFormat extends PrintFormat {
     /// {"row": 0, "col": 4, "value": 2.1}]
     /// ```
     public final static MapPrintFormat PYTHON = new MapPrintFormat(
-            DEFAULT_PRECISION, ": ", ", ", "{", "}", ",\n", "[", "]").withKeyPrefix("\"").withKeySuffix("\"");
+            DEFAULT_PRECISION, ": ", ", ", "{", "}", ", ", "[", "]").withFormatKey(( key ) -> '"' + key + '"');
 
     /// JSON style:
     ///
@@ -66,7 +71,7 @@ public class MapPrintFormat extends PrintFormat {
     ///   value: 2.1
     /// ```
     public final static MapPrintFormat YAML = new MapPrintFormat(
-            DEFAULT_PRECISION, ": ", "\n  ", "- ", "", "\n", "", "");
+            DEFAULT_PRECISION, ": ", ", ", "{", "}", ", ", "[", "]");
 
     /// Java style:
     ///
@@ -76,8 +81,8 @@ public class MapPrintFormat extends PrintFormat {
     ///         Map.of("row", 0, "col", 4, "value", 2.1))
     /// ```
     ///
-    public final static MapPrintFormat JAVA = new MapPrintFormat(DEFAULT_PRECISION, ", ", ", ", "Map.of(", ")", ",\n        ", "List.of(", ")")
-            .withKeyPrefix("\"").withKeySuffix("\"");
+    public final static MapPrintFormat JAVA = new MapPrintFormat(DEFAULT_PRECISION, ", ", ", ", "Map.of(", ")", ", ", "List.of(", ")")
+            .withFormatKey(( key ) -> '"' + key + '"');
 
     /// Separator that splits key-value pairs
     @Getter @Setter public String valueSeparator = ": ";
@@ -88,15 +93,15 @@ public class MapPrintFormat extends PrintFormat {
     /// Suffix for an item in the list. If a single item, this is still applied.
     @Getter @Setter public String itemSuffix = "}";
     /// Separator applied after each item in the list
-    @Getter @Setter public String itemSeparator = ",\n";
+    @Getter @Setter public String itemSeparator = ", ";
     /// Prefix applied before the list
     @Getter @Setter public String listPrefix = "[";
     /// Prefix applied after the list
     @Getter @Setter public String listSuffix = "]";
-    /// Prefix added before each key. Use to quote keys for languages that require it.
-    @Getter @Setter public String keyPrefix = "";
-    /// Suffix added after each key.
-    @Getter @Setter public String keySuffix = "";
+    /// Encodes a String to be used as a key. By default, it returns the same string.
+    @Getter @Setter public Function<String, String> formatKey = ( txt ) -> txt;
+    /// Encode a String. By default, this adds quotes to both sides.
+    @Getter @Setter public Function<String, String> encodeStr = ( txt ) -> "\"" + txt + "\"";
 
     public MapPrintFormat() {}
 
@@ -117,7 +122,7 @@ public class MapPrintFormat extends PrintFormat {
     ///
     /// @param isMore Are there more pairs that need to be added. If true it will add a separator
     public void pair( StringBuilder builder, String name, double value, boolean isMore ) {
-        builder.append(keyPrefix).append(name).append(keySuffix);
+        builder.append(formatKey.apply(name));
         builder.append(valueSeparator);
         builder.append(f(value));
         if (isMore)
@@ -128,31 +133,79 @@ public class MapPrintFormat extends PrintFormat {
     ///
     /// @param isMore Are there more pairs that need to be added. If true it will add a separator
     public String pair( String name, double value, boolean isMore ) {
-        String txt = keyPrefix + name + keySuffix + valueSeparator + f(value);
+        String txt = formatKey.apply(name) + valueSeparator + f(value);
         return txt + (isMore ? pairSeparator : "");
     }
 
     public String pair( String name, String value, boolean isMore ) {
-        String txt = keyPrefix + name + keySuffix + valueSeparator + value;
+        String txt = formatKey.apply(name) + valueSeparator + value;
         return txt + (isMore ? pairSeparator : "");
     }
 
     public void pair( StringBuilder builder, String name, double @Nullable [] values, boolean isMore ) {
-        builder.append(keyPrefix).append(name).append(keySuffix);
+        builder.append(formatKey.apply(name));
         builder.append(valueSeparator);
-        builder.append(itemPrefix);
-        f(builder, pairSeparator, values);
-        builder.append(itemSuffix);
+        builder.append(listPrefix);
+        f(builder, itemSeparator, values);
+        builder.append(listSuffix);
         if (isMore)
             builder.append(pairSeparator);
     }
 
     public void pair( StringBuilder builder, String name, float @Nullable [] values, boolean isMore ) {
-        builder.append(keyPrefix).append(name).append(keySuffix);
+        builder.append(formatKey.apply(name));
         builder.append(valueSeparator);
-        builder.append(itemPrefix);
-        f(builder, pairSeparator, values);
+        builder.append(listPrefix);
+        f(builder, itemSeparator, values);
+        builder.append(listSuffix);
+        if (isMore)
+            builder.append(pairSeparator);
+    }
+
+    public void pair( StringBuilder builder, String name, long @Nullable [] values, boolean isMore ) {
+        builder.append(formatKey.apply(name));
+        builder.append(valueSeparator);
+        builder.append(listPrefix);
+        if (values != null && values.length > 0) {
+            for (int i = 0; i < values.length - 1; i++) {
+                builder.append(values[i]);
+                builder.append(itemSeparator);
+            }
+            builder.append(values[values.length - 1]);
+        }
+        builder.append(listSuffix);
+        if (isMore)
+            builder.append(pairSeparator);
+    }
+
+    public void pair( StringBuilder builder, String name, int @Nullable [] values, boolean isMore ) {
+        builder.append(formatKey.apply(name));
+        builder.append(valueSeparator);
+        builder.append(listPrefix);
+        if (values != null && values.length > 0) {
+            for (int i = 0; i < values.length - 1; i++) {
+                builder.append(values[i]);
+                builder.append(itemSeparator);
+            }
+            builder.append(values[values.length - 1]);
+        }
         builder.append(itemSuffix);
+        if (isMore)
+            builder.append(pairSeparator);
+    }
+
+    public void pair( StringBuilder builder, String name, String @Nullable [] values, boolean isMore ) {
+        builder.append(formatKey.apply(name));
+        builder.append(valueSeparator);
+        builder.append(listPrefix);
+        if (values != null && values.length > 0) {
+            for (int i = 0; i < values.length - 1; i++) {
+                builder.append(values[i]);
+                builder.append(itemSeparator);
+            }
+            builder.append(values[values.length - 1]);
+        }
+        builder.append(listSuffix);
         if (isMore)
             builder.append(pairSeparator);
     }
@@ -227,13 +280,13 @@ public class MapPrintFormat extends PrintFormat {
         return this;
     }
 
-    public MapPrintFormat withKeyPrefix( String txt ) {
-        this.keyPrefix = txt;
+    public MapPrintFormat withEncodeStr( Function<String, String> op ) {
+        this.encodeStr = op;
         return this;
     }
 
-    public MapPrintFormat withKeySuffix( String txt ) {
-        this.keySuffix = txt;
+    public MapPrintFormat withFormatKey( Function<String, String> op ) {
+        this.formatKey = op;
         return this;
     }
 
@@ -252,8 +305,8 @@ public class MapPrintFormat extends PrintFormat {
         this.listPrefix = src.listPrefix;
         this.listSuffix = src.listSuffix;
         this.decimal = src.decimal;
-        this.keyPrefix = src.keyPrefix;
-        this.keySuffix = src.keySuffix;
+        this.encodeStr = src.encodeStr;
+        this.formatKey = src.encodeStr;
         return this;
     }
 }

--- a/main/ejml-core/src/org/ejml/MapPrintReflect.java
+++ b/main/ejml-core/src/org/ejml/MapPrintReflect.java
@@ -51,9 +51,13 @@ public final class MapPrintReflect {
         // ("is there a following pair?") logic stays correct even if a field is skipped.
         List<String> names = new ArrayList<>(fields.length);
         List<Object> values = new ArrayList<>(fields.length);
-        for (Field field : fields) {
+        for (int i = 0; i < fields.length; i++) {
+            Field field = fields[i];
             try {
-                values.add(field.get(object));
+                Object value = field.get(object);
+                if (value == null)
+                    continue;
+                values.add(value);
                 names.add(field.getName());
             } catch (IllegalAccessException ignore) { /* skip */ }
         }
@@ -61,8 +65,7 @@ public final class MapPrintReflect {
         var builder = new StringBuilder();
         builder.append(format.itemPrefix);
         for (int i = 0; i < names.size(); i++) {
-            boolean isMore = i + 1 < names.size();
-            appendValue(builder, format, names.get(i), values.get(i), isMore);
+            appendValue(builder, format, names.get(i), values.get(i), i != names.size() - 1);
         }
         builder.append(format.itemSuffix);
         return builder.toString();
@@ -75,6 +78,7 @@ public final class MapPrintReflect {
 
         List<Field> list = new ArrayList<>();
         for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
+            // lint:forbidden ignore_below
             for (Field f : c.getDeclaredFields()) {
                 if (Modifier.isStatic(f.getModifiers()) || f.isSynthetic())
                     continue;
@@ -94,7 +98,8 @@ public final class MapPrintReflect {
     private static void appendValue( StringBuilder b, MapPrintFormat format,
                                      String name, Object value, boolean isMore ) {
         if (value == null) {
-            b.append(format.pair(name, "null", isMore));
+            // just skip null value. No good generic way to handle it
+//            b.append(format.pair(name, "null", isMore));
         } else if (value instanceof MapFormattable mf) {
             appendKey(b, format, name);
             b.append(mf.formatMap(format));   // recurse
@@ -108,7 +113,7 @@ public final class MapPrintReflect {
         } else if (value.getClass().isArray()) {
             appendArray(b, format, name, value, isMore);
         } else if (value instanceof String s) {
-            b.append(format.pair(name, s, isMore));
+            b.append(format.pair(name, format.encodeStr.apply(s), isMore));
         } else {
             // Boolean, Character, enum, or any other object
             b.append(format.pair(name, value.toString(), isMore));
@@ -130,25 +135,22 @@ public final class MapPrintReflect {
         }
 
         // boolean[], char[], String[], Object[], MapFormattable[], ...
-        appendKey(b, format, name);
-        b.append(format.itemPrefix);
+        String[] copy = new String[len];
         for (int i = 0; i < len; i++) {
-            if (i > 0) b.append(format.pairSeparator);
-            b.append(formatElement(format, Array.get(array, i)));
+            Object o = Array.get(array, i);
+            if (o instanceof MapFormattable m) {
+                copy[i] = m.formatMap(format);
+            } else if (o instanceof String s) {
+                copy[i] = format.encodeStr.apply(s);
+            } else {
+                copy[i] = o.toString();
+            }
         }
-        b.append(format.itemSuffix);
-        appendTrailing(b, format, isMore);
-    }
-
-    private static String formatElement( MapPrintFormat format, Object el ) {
-        if (el == null) return "null";
-        if (el instanceof MapFormattable mf) return mf.formatMap(format);
-        return el.toString();
+        format.pair(b, name, copy, isMore);
     }
 
     private static void appendKey( StringBuilder b, MapPrintFormat format, String name ) {
-        b.append(format.keyPrefix).append(name).append(format.keySuffix)
-                .append(format.valueSeparator);
+        b.append(format.formatKey.apply(name)).append(format.valueSeparator);
     }
 
     private static void appendTrailing( StringBuilder b, MapPrintFormat format, boolean isMore ) {

--- a/main/ejml-core/test/org/ejml/TestMapPrintFormat.java
+++ b/main/ejml-core/test/org/ejml/TestMapPrintFormat.java
@@ -23,6 +23,38 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestMapPrintFormat extends EjmlStandardJUnit {
+    @Test void DEFAULT() {
+        String found = new FormatStress().formatMap(MapPrintFormat.DEFAULT);
+        assertEquals("{d0: 1.123456, f0: 4.123456, c0: -324, str0: \"asdf\", arrStr0: [\"cat\", \"dog\"]," +
+                " arrD0: [0.456, -0.312, 567.3], arrF0: [0.216, -0.804, 3744.429932], " +
+                "arrI0: [-4, 95, 0], inner: {x: 40, y: 9.34}}", found);
+    }
+
+    @Test void YAML() {
+        var stress = new FormatStress();
+        String found = stress.formatMap(MapPrintFormat.YAML);
+        assertEquals("{d0: 1.123456, f0: 4.123456, c0: -324, str0: \"asdf\", arrStr0: [\"cat\", \"dog\"]," +
+                " arrD0: [0.456, -0.312, 567.3], arrF0: [0.216, -0.804, 3744.429932], arrI0: [-4, 95, 0], " +
+                "inner: {x: 40, y: 9.34}}", found);
+    }
+
+    @Test void JSON() {
+        var stress = new FormatStress();
+        String found = stress.formatMap(MapPrintFormat.JSON);
+        assertEquals("{\"d0\": 1.123456, \"f0\": 4.123456, \"c0\": -324, \"str0\": \"asdf\", " +
+                "\"arrStr0\": [\"cat\", \"dog\"], \"arrD0\": [0.456, -0.312, 567.3], " +
+                "\"arrF0\": [0.216, -0.804, 3744.429932], \"arrI0\": [-4, 95, 0], " +
+                "\"inner\": {\"x\": 40, \"y\": 9.34}}", found);
+    }
+
+    @Test void JAVA() {
+        String found = new FormatStress().formatMap(MapPrintFormat.JAVA);
+        assertEquals("Map.of(\"d0\", 1.123456, \"f0\", 4.123456, \"c0\", -324, \"str0\", \"asdf\", " +
+                "\"arrStr0\", List.of(\"cat\", \"dog\"), \"arrD0\", List.of(0.456, -0.312, 567.3), " +
+                "\"arrF0\", List.of(0.216, -0.804, 3744.429932), \"arrI0\", List.of(-4, 95, 0), \"inner\", " +
+                "Map.of(\"x\", 40, \"y\", 9.34))", found);
+    }
+
     @Test void pair_builder_double() {
         var builder = new StringBuilder();
         var alg = new MapPrintFormat();
@@ -53,11 +85,11 @@ public class TestMapPrintFormat extends EjmlStandardJUnit {
         var alg = new MapPrintFormat();
         alg.precision = 3;
         alg.pair(builder, "foo", new double[]{1, 2, 3.1234}, true);
-        assertEquals("foo: {1, 2, 3.123}, ", builder.toString());
+        assertEquals("foo: [1, 2, 3.123], ", builder.toString());
 
         builder.delete(0, builder.length());
         alg.pair(builder, "foo", new double[]{1, 2, 3.1234}, false);
-        assertEquals("foo: {1, 2, 3.123}", builder.toString());
+        assertEquals("foo: [1, 2, 3.123]", builder.toString());
     }
 
     @Test void pair_builder_float_array() {
@@ -65,11 +97,11 @@ public class TestMapPrintFormat extends EjmlStandardJUnit {
         var alg = new MapPrintFormat();
         alg.precision = 3;
         alg.pair(builder, "foo", new float[]{1, 2, 3.1234f}, true);
-        assertEquals("foo: {1, 2, 3.123}, ", builder.toString());
+        assertEquals("foo: [1, 2, 3.123], ", builder.toString());
 
         builder.delete(0, builder.length());
         alg.pair(builder, "foo", new float[]{1, 2, 3.1234f}, false);
-        assertEquals("foo: {1, 2, 3.123}", builder.toString());
+        assertEquals("foo: [1, 2, 3.123]", builder.toString());
     }
 
     @Test void tostring_MapPrintFormat() {
@@ -82,6 +114,31 @@ public class TestMapPrintFormat extends EjmlStandardJUnit {
     private static class WorkObj implements MapFormattable {
         @Override public String formatMap( MapPrintFormat format ) {
             return "foo";
+        }
+    }
+
+    public static class InnerStress implements MapFormattable {
+        public int x = 40;
+        public double y = 9.34;
+
+        @Override public String formatMap( MapPrintFormat format ) {
+            return MapPrintReflect.formatMap(this, format);
+        }
+    }
+
+    public static class FormatStress implements MapFormattable {
+        public double d0 = 1.123456;
+        public float f0 = 4.123456f;
+        public int c0 = -324;
+        public String str0 = "asdf";
+        public String[] arrStr0 = new String[]{"cat", "dog"};
+        public double[] arrD0 = new double[]{0.456, -0.312, 567.3};
+        public float[] arrF0 = new float[]{0.216f, -0.804f, 3744.43f};
+        public int[] arrI0 = new int[]{-4, 95, 0};
+        public InnerStress inner = new InnerStress();
+
+        @Override public String formatMap( MapPrintFormat format ) {
+            return MapPrintReflect.formatMap(this, format);
         }
     }
 }

--- a/main/ejml-core/test/org/ejml/TestMapPrintReflection.java
+++ b/main/ejml-core/test/org/ejml/TestMapPrintReflection.java
@@ -22,22 +22,5 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestMapPrintReflection {
-    @Test void basic() {
-        var a = new Foo();
-        String found = a.formatMap(new MapPrintFormat().withPrecision(2));
-        assertEquals("{moo: 1.12, too: 2.36, zoo: -23, poo: a, stuff: {-9, 4, 2}}", found);
-    }
-
-    public static class Foo implements MapFormattable {
-        double moo = 1.123456;
-        float too = 2.3567f;
-        int zoo = -23;
-        char poo = 'a';
-        int[] stuff = new int[]{-9, 4, 2};
-
-        @Override public String formatMap( MapPrintFormat format ) {
-            return MapPrintReflect.formatMap(this, format);
-        }
-    }
-}
+// intentionally empty. This is tested rigorously in TestMapPrintFormat
+public class TestMapPrintReflection extends EjmlStandardJUnit {}

--- a/main/ejml-core/test/org/ejml/data/TestDMatrixSparseCSC.java
+++ b/main/ejml-core/test/org/ejml/data/TestDMatrixSparseCSC.java
@@ -154,8 +154,8 @@ public class TestDMatrixSparseCSC extends GenericTestsDMatrixSparse {
         a.set(3, 1, 3.966);
 
         String found = a.formatMap(new MapPrintFormat().withPrecision(2));
-        assertEquals("[{row: 3, col: 1, value: 3.97},\n" +
-                "{row: 1, col: 2, value: 1.23},\n" +
+        assertEquals("[{row: 3, col: 1, value: 3.97}, " +
+                "{row: 1, col: 2, value: 1.23}, " +
                 "{row: 0, col: 4, value: 2.1}]", found);
     }
 }


### PR DESCRIPTION
- Strings are now handled by a lambda
- Generates valid YAML another encodings
- Everything is on one line now in all formats

Thank you for your contribution to the EJML project.

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please make sure:
- [ ] Your code is covered by tests
- [ ] You ran `./gradlew spotlessJavaApply`