### PR TITLE
Fix sparse LU/QR/Cholesky fill-reduction permutations

### DIFF
--- a/buildSrc/src/main/kotlin/ejml.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ejml.java-conventions.gradle.kts
@@ -77,8 +77,12 @@ tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
 }
 
-// Produces Java 11 bytecode but accepts Java 25 syntax (via Jabel)
+// Produces Java 11 bytecode but accepts Java 25 syntax (via Jabel). Skip the `generate`/`benchmarks`
+// source sets: they're never shipped, only ever run on the JDK driving the build, and (unlike main/test)
+// have no Jabel annotation processor attached to let them use modern syntax under -release 11.
 tasks.withType<JavaCompile>().configureEach {
+    if (name == "compileGenerateJava" || name == "compileBenchmarksJava")
+        return@configureEach
     sourceCompatibility = "25"
     options.release.set(11)
 }

--- a/buildSrc/src/main/kotlin/ejml.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ejml.java-conventions.gradle.kts
@@ -77,12 +77,8 @@ tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
 }
 
-// Produces Java 11 bytecode but accepts Java 25 syntax (via Jabel). Skip the `generate`/`benchmarks`
-// source sets: they're never shipped, only ever run on the JDK driving the build, and (unlike main/test)
-// have no Jabel annotation processor attached to let them use modern syntax under -release 11.
+// Produces Java 11 bytecode but accepts Java 25 syntax (via Jabel)
 tasks.withType<JavaCompile>().configureEach {
-    if (name == "compileGenerateJava" || name == "compileBenchmarksJava")
-        return@configureEach
     sourceCompatibility = "25"
     options.release.set(11)
 }

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/lu/LuUpLooking_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/lu/LuUpLooking_DSCC.java
@@ -34,6 +34,10 @@ import static org.ejml.UtilEjml.permutationSign;
 /**
  * LU Decomposition using a left looking algorithm for {@link DMatrixSparseCSC}.
  *
+ * <p>If a fill reduction permutation is provided, the matrix which is factored is P*A*Q, where P and Q are the
+ * ordering's row and column permutations, i.e. L*U = P<sub>pivot</sub>*P*A*Q where P<sub>pivot</sub> is the
+ * row pivoting selected numerically ({@link #getRowPivot}).</p>
+ *
  * <p>NOTE: Based mostly on the algorithm described on page 86 in csparse. cs_lu</p>
  * <p>NOTE: See in code comment for a modification from csparse.</p>
  *
@@ -93,7 +97,6 @@ public class LuUpLooking_DSCC
     private boolean performLU( DMatrixSparseCSC A ) {
         int m = A.numRows;
         int n = A.numCols;
-        int[] q = applyReduce.getArrayP();
 
         int[] w = UtilEjml.adjust(gw, m*2, m);
 
@@ -109,8 +112,8 @@ public class LuUpLooking_DSCC
             if (U.nz_length + n > U.nz_values.length)
                 U.growMaxLength(2*U.nz_values.length + n, true);
 
-            int col = q != null ? q[k] : k;
-            int top = TriangularSolver_DSCC.solveColB(L, true, A, col, x, pinv, gxi, w);
+            // any fill reduction permutation has already been applied to A, so column k is processed directly
+            int top = TriangularSolver_DSCC.solveColB(L, true, A, k, x, pinv, gxi, w);
             int[] xi = gxi.data;
 
             //--------- Find the Next Pivot. That will be the row with the largest value
@@ -135,11 +138,11 @@ public class LuUpLooking_DSCC
                 return false;
             }
 
-            // NOTE: The line is commented out below. It can cause a poor pivot to be selected. Instead of the largest
-            //       row it will pick whatever is in this column. it does try to make sure it's not zero, but I'm not
-            //       sure what it's purpose is.
-//            if( pinv[col] < 0 && Math.abs(x[col]) >= a*tol ) {
-//                ipiv = col;
+            // NOTE: csparse prefers the diagonal entry when it's within 'tol' of the largest pivot candidate. This
+            //       preserves more of a symmetric fill reducing ordering's structure under pivoting. Since A is
+            //       already permuted here, the diagonal candidate is x[k].
+//            if( pinv[k] < 0 && Math.abs(x[k]) >= a*tol ) {
+//                ipiv = k;
 //            }
 
             //---------- Divide by the pivot
@@ -177,10 +180,16 @@ public class LuUpLooking_DSCC
     }
 
     @Override
+    @SuppressWarnings("NullAway") // arrays are not null when a fill reduction has been applied
     public Complex_F64 computeDeterminant() {
         // see dense algorithm. There is probably a faster way to compute the sign while decomposing
         // the matrix.
         double value = permutationSign(pinv, U.numCols, gw.data);
+        if (applyReduce.isApplied()) {
+            // the fill reduction row and column permutations also affect the determinant's sign
+            value *= permutationSign(applyReduce.getArrayP(), U.numCols, gw.data);
+            value *= permutationSign(applyReduce.getArrayQ(), U.numCols, gw.data);
+        }
         for (int i = 0; i < U.numCols; i++) {
             value *= U.nz_values[U.col_idx[i + 1] - 1];
         }
@@ -263,6 +272,11 @@ public class LuUpLooking_DSCC
         if (ret == null)
             throw new RuntimeException("Check to see if there is any fill reduce ordering to apply first");
         return ret;
+    }
+
+    /** Handles applying the fill reduction permutation to the matrix and to solve vectors. */
+    public ApplyFillReductionPermutation_DSCC getApplyFillReduction() {
+        return applyReduce;
     }
 
     @Override

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/qr/QrLeftLookingDecomposition_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/decomposition/qr/QrLeftLookingDecomposition_DSCC.java
@@ -98,7 +98,6 @@ public class QrLeftLookingDecomposition_DSCC implements
 
     private void performDecomposition( DMatrixSparseCSC A ) {
         int[] w = gwork.data;
-        int[] permCol = applyReduce.getArrayQ();
         int[] parent = structure.getParent();
         int[] leftmost = structure.getLeftMost();
         // permutation that was done to ensure all rows have non-zero elements
@@ -120,10 +119,10 @@ public class QrLeftLookingDecomposition_DSCC implements
             w[k] = k;
             V.nz_rows[V.nz_length++] = k;                       // Add V(k,k) to V's pattern
             int top = n;
-            int col = permCol != null ? permCol[k] : k;
-
-            int idx0 = A.col_idx[col];
-            int idx1 = A.col_idx[col + 1];
+            // any fill reduction permutation has already been applied to A, so column k is processed directly.
+            // this must match the column ordering seen by the structure computation.
+            int idx0 = A.col_idx[k];
+            int idx1 = A.col_idx[k + 1];
 
             for (int p = idx0; p < idx1; p++) {
                 int i = leftmost[A.nz_rows[p]];
@@ -277,6 +276,11 @@ public class QrLeftLookingDecomposition_DSCC implements
         if (ret == null)
             throw new RuntimeException("No permutation. Should have called isFillPermuted()");
         return ret;
+    }
+
+    /** Handles applying the fill reduction permutation to the matrix and to solve vectors. */
+    public ApplyFillReductionPermutation_DSCC getApplyFillReduction() {
+        return applyReduce;
     }
 
     public boolean isFillPermutated() {

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/chol/LinearSolverCholesky_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/chol/LinearSolverCholesky_DSCC.java
@@ -50,6 +50,7 @@ public class LinearSolverCholesky_DSCC implements LinearSolverSparse<DMatrixSpar
     IGrowArray gw = new IGrowArray();
 
     DMatrixSparseCSC tmp = new DMatrixSparseCSC(1, 1, 1);
+    DMatrixSparseCSC tmp2 = new DMatrixSparseCSC(1, 1, 1);
 
     // Number of rows in A
     int AnumRows, AnumCols;
@@ -73,6 +74,7 @@ public class LinearSolverCholesky_DSCC implements LinearSolverSparse<DMatrixSpar
     }
 
     @Override
+    @SuppressWarnings("NullAway") // rowPinv is not null when the fill reduction has been applied
     public void solveSparse( DMatrixSparseCSC B, DMatrixSparseCSC X ) {
         X.reshape(AnumCols, B.numCols, X.numRows);
 
@@ -80,11 +82,27 @@ public class LinearSolverCholesky_DSCC implements LinearSolverSparse<DMatrixSpar
 
         DMatrixSparseCSC L = cholesky.getL();
 
-        tmp.reshape(L.numRows, B.numCols, 1);
-        int[] Pinv = reduce.getArrayPinv();
+        // Cholesky has no numeric pivots, so the row permutation is just the fill reduction (null if none)
+        int[] rowPinv = reduce.fillRowPermInv();
 
-        TriangularSolver_DSCC.solve(L, true, B, tmp, Pinv, gx, gw, gw1);
-        TriangularSolver_DSCC.solveTran(L, true, tmp, X, null, gx, gw, gw1);
+        // apply the fill reduction permutation to B
+        DMatrixSparseCSC Bp = B;
+        if (reduce.isApplied()) {
+            tmp2.reshape(B.numRows, B.numCols, B.nz_length);
+            CommonOps_DSCC.permute(rowPinv, B, null, tmp2);
+            Bp = tmp2;
+        }
+
+        tmp.reshape(L.numRows, B.numCols, 1);
+        TriangularSolver_DSCC.solve(L, true, Bp, tmp, null, gx, gw, gw1);
+        if (reduce.isApplied()) {
+            // solve into scratch storage, then undo the fill reduction permutation
+            tmp2.reshape(L.numRows, B.numCols, 1);
+            TriangularSolver_DSCC.solveTran(L, true, tmp, tmp2, null, gx, gw, gw1);
+            reduce.undoColumnPermutation(tmp2, X);
+        } else {
+            TriangularSolver_DSCC.solveTran(L, true, tmp, X, null, gx, gw, gw1);
+        }
     }
 
     @Override
@@ -98,6 +116,7 @@ public class LinearSolverCholesky_DSCC implements LinearSolverSparse<DMatrixSpar
     }
 
     @Override
+    @SuppressWarnings("NullAway") // rowPinv is not null when the fill reduction has been applied
     public void solve( DMatrixRMaj B, DMatrixRMaj X ) {
         UtilEjml.checkReshapeSolve(AnumRows, AnumCols, B, X);
 
@@ -108,17 +127,18 @@ public class LinearSolverCholesky_DSCC implements LinearSolverSparse<DMatrixSpar
         double[] b = adjust(gb, N);
         double[] x = adjust(gx, N);
 
-        int[] Pinv = reduce.getArrayPinv();
+        // Cholesky has no numeric pivots, so the row permutation is just the fill reduction (null if none)
+        int[] rowPinv = reduce.fillRowPermInv();
 
         for (int col = 0; col < B.numCols; col++) {
             int index = col;
             for (int i = 0; i < N; i++, index += B.numCols) b[i] = B.data[index];
 
-            if (Pinv != null) {
-                CommonOps_DSCC.permuteInv(Pinv, b, x, N);
+            if (reduce.isApplied()) {
+                CommonOps_DSCC.permuteInv(rowPinv, b, x, N);
                 TriangularSolver_DSCC.solveL(L, x);
                 TriangularSolver_DSCC.solveTranL(L, x);
-                CommonOps_DSCC.permute(Pinv, x, b, N);
+                reduce.undoColumnPermutation(x, b, N);
             } else {
                 TriangularSolver_DSCC.solveL(L, b);
                 TriangularSolver_DSCC.solveTranL(L, b);

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/lu/LinearSolverLu_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/lu/LinearSolverLu_DSCC.java
@@ -27,6 +27,7 @@ import org.ejml.interfaces.decomposition.DecompositionInterface;
 import org.ejml.interfaces.linsol.LinearSolverSparse;
 import org.ejml.sparse.csc.CommonOps_DSCC;
 import org.ejml.sparse.csc.decomposition.lu.LuUpLooking_DSCC;
+import org.ejml.sparse.csc.misc.ApplyFillReductionPermutation_DSCC;
 import org.ejml.sparse.csc.misc.TriangularSolver_DSCC;
 
 import static org.ejml.UtilEjml.adjust;
@@ -42,6 +43,7 @@ public class LinearSolverLu_DSCC implements LinearSolverSparse<DMatrixSparseCSC,
 
     private final DGrowArray gx = new DGrowArray();
     private final DGrowArray gb = new DGrowArray();
+    private final IGrowArray gwork = new IGrowArray();
 
     DMatrixSparseCSC Bp = new DMatrixSparseCSC(1, 1, 1);
     DMatrixSparseCSC tmp = new DMatrixSparseCSC(1, 1, 1);
@@ -71,11 +73,12 @@ public class LinearSolverLu_DSCC implements LinearSolverSparse<DMatrixSparseCSC,
 
         DMatrixSparseCSC L = decomposition.getL();
         DMatrixSparseCSC U = decomposition.getU();
+        ApplyFillReductionPermutation_DSCC reduce = decomposition.getApplyFillReduction();
 
-        // these are row pivots
+        // apply the fill reduction row permutation composed with the numeric row pivots to B
+        int[] rowPinv = reduce.rowPermInv(decomposition.getPinv(), gwork);
         Bp.reshape(B.numRows, B.numCols, B.nz_length);
-        int[] Pinv = decomposition.getPinv();
-        CommonOps_DSCC.permute(Pinv, B, null, Bp);
+        CommonOps_DSCC.permute(rowPinv, B, null, Bp);
 
         IGrowArray gw = decomposition.getGw();
         IGrowArray gw1 = decomposition.getGxi();
@@ -83,7 +86,13 @@ public class LinearSolverLu_DSCC implements LinearSolverSparse<DMatrixSparseCSC,
         tmp.reshape(L.numRows, B.numCols, 1);
 
         TriangularSolver_DSCC.solve(L, true, Bp, tmp, null, gx, gw, gw1);
-        TriangularSolver_DSCC.solve(U, false, tmp, X, null, gx, gw, gw1);
+        if (reduce.isApplied()) {
+            // solve into scratch storage, then undo the fill reduction column permutation
+            TriangularSolver_DSCC.solve(U, false, tmp, Bp, null, gx, gw, gw1);
+            reduce.undoColumnPermutation(Bp, X);
+        } else {
+            TriangularSolver_DSCC.solve(U, false, tmp, X, null, gx, gw, gw1);
+        }
     }
 
     @Override
@@ -97,31 +106,31 @@ public class LinearSolverLu_DSCC implements LinearSolverSparse<DMatrixSparseCSC,
     }
 
     @Override
-    @SuppressWarnings("NullAway") // Compiler isn't smart enough to realize null condition is impossible
     public void solve( DMatrixRMaj B, DMatrixRMaj X ) {
         UtilEjml.checkReshapeSolve(AnumRows, AnumCols, B, X);
 
-        int[] pinv = decomposition.getPinv();
         double[] x = adjust(gx, X.numRows);
         double[] b = adjust(gb, B.numRows);
 
         DMatrixSparseCSC L = decomposition.getL();
         DMatrixSparseCSC U = decomposition.getU();
+        ApplyFillReductionPermutation_DSCC reduce = decomposition.getApplyFillReduction();
 
-        final boolean reduceFill = decomposition.isReduceFill();
-        final int[] q = reduceFill ? decomposition.getReducePermutation() : null;
+        // inverse row permutation to apply to b = (fill reduction rows) composed with (numeric pivots)
+        int[] rowPinv = reduce.rowPermInv(decomposition.getPinv(), gwork);
 
         // process each column in X and B individually
         for (int colX = 0; colX < X.numCols; colX++) {
             int index = colX;
             for (int i = 0; i < B.numRows; i++, index += X.numCols) b[i] = B.data[index];
 
-            CommonOps_DSCC.permuteInv(pinv, b, x, X.numRows);
+            CommonOps_DSCC.permuteInv(rowPinv, b, x, X.numRows);
             TriangularSolver_DSCC.solveL(L, x);
             TriangularSolver_DSCC.solveU(U, x);
             double[] d;
-            if (reduceFill) {
-                CommonOps_DSCC.permute(q, x, b, X.numRows);
+            if (reduce.isApplied()) {
+                // undo the fill reduction column permutation
+                reduce.undoColumnPermutation(x, b, X.numRows);
                 d = b;
             } else {
                 d = x;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/qr/LinearSolverQrLeftLooking_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/linsol/qr/LinearSolverQrLeftLooking_DSCC.java
@@ -28,6 +28,7 @@ import org.ejml.interfaces.linsol.LinearSolverSparse;
 import org.ejml.sparse.csc.CommonOps_DSCC;
 import org.ejml.sparse.csc.decomposition.qr.QrHelperFunctions_DSCC;
 import org.ejml.sparse.csc.decomposition.qr.QrLeftLookingDecomposition_DSCC;
+import org.ejml.sparse.csc.misc.ApplyFillReductionPermutation_DSCC;
 import org.ejml.sparse.csc.misc.TriangularSolver_DSCC;
 
 import static org.ejml.UtilEjml.adjust;
@@ -46,6 +47,7 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
     private final DGrowArray gbp = new DGrowArray();
     private final DGrowArray gx = new DGrowArray();
     private final IGrowArray gw = new IGrowArray();
+    private final IGrowArray gwork = new IGrowArray();
 
     private final DMatrixSparseCSC tmp = new DMatrixSparseCSC(1, 1, 1);
 
@@ -72,6 +74,7 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
         X.reshape(AnumCols, B.numCols, X.numRows);
 
         IGrowArray gw1 = qr.getGwork();
+        ApplyFillReductionPermutation_DSCC reduce = qr.getApplyFillReduction();
 
         // Don't modify the input
         tmp.setTo(B);
@@ -79,8 +82,8 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
         DMatrixSparseCSC B_tmp = B.createLike();
         DMatrixSparseCSC swap;
 
-        // Apply permutation to B
-        int[] pinv = qr.getStructure().getPinv();
+        // Apply the fill reduction row permutation composed with the structural row permutation to B
+        int[] pinv = reduce.rowPermInv(qr.getStructure().getPinv(), gwork);
         CommonOps_DSCC.permuteRowInv(pinv, B, B_tmp);
         swap = B_tmp;
         B_tmp = B;
@@ -97,7 +100,14 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
 
         // Solve for X
         DMatrixSparseCSC R = qr.getR();
-        TriangularSolver_DSCC.solve(R, false, B, X, null, gx, gw, gw1);
+        if (reduce.isApplied()) {
+            // solve into scratch storage, then undo the fill reduction column permutation
+            B_tmp.reshape(AnumCols, B.numCols, 1);
+            TriangularSolver_DSCC.solve(R, false, B, B_tmp, null, gx, gw, gw1);
+            reduce.undoColumnPermutation(B_tmp, X);
+        } else {
+            TriangularSolver_DSCC.solve(R, false, B, X, null, gx, gw, gw1);
+        }
     }
 
     @Override
@@ -118,7 +128,10 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
         double[] bp = adjust(gbp, B.numRows);
         double[] x = adjust(gx, AnumCols);
 
-        int[] pinv = qr.getStructure().getPinv();
+        ApplyFillReductionPermutation_DSCC reduce = qr.getApplyFillReduction();
+
+        // inverse row permutation to apply to b = (fill reduction rows) composed with (structural row pivots)
+        int[] rowPinv = reduce.rowPermInv(qr.getStructure().getPinv(), gwork);
 
         // process each column in X and B individually
         for (int colX = 0; colX < B.numCols; colX++) {
@@ -126,7 +139,7 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
             for (int i = 0; i < B.numRows; i++, index += X.numCols) b[i] = B.data[index];
 
             // apply row pivots
-            CommonOps_DSCC.permuteInv(pinv, b, bp, AnumRows);
+            CommonOps_DSCC.permuteInv(rowPinv, b, bp, AnumRows);
 
             // apply Householder reflectors
             for (int j = 0; j < AnumCols; j++) {
@@ -135,10 +148,10 @@ public class LinearSolverQrLeftLooking_DSCC implements LinearSolverSparse<DMatri
             // Solve for R*x = b
             TriangularSolver_DSCC.solveU(qr.getR(), bp);
 
-            // undo the permutation
+            // undo the fill reduction column permutation
             double[] out;
-            if (qr.isFillPermutated()) {
-                CommonOps_DSCC.permute(qr.getFillPermutation(), bp, x, X.numRows);
+            if (reduce.isApplied()) {
+                reduce.undoColumnPermutation(bp, x, X.numRows);
                 out = x;
             } else {
                 out = bp;

--- a/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ApplyFillReductionPermutation_DSCC.java
+++ b/main/ejml-dsparse/src/org/ejml/sparse/csc/misc/ApplyFillReductionPermutation_DSCC.java
@@ -18,6 +18,7 @@
 
 package org.ejml.sparse.csc.misc;
 
+import org.ejml.UtilEjml;
 import org.ejml.data.DMatrixSparseCSC;
 import org.ejml.data.IGrowArray;
 import org.ejml.sparse.ComputePermutation;
@@ -25,9 +26,12 @@ import org.ejml.sparse.csc.CommonOps_DSCC;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Applies the fill reduction row pivots to the input matrix to reduce fill in during decomposition/solve.
+ * Applies the fill reduction permutation to the input matrix to reduce fill in during decomposition/solve.
  *
- * P*A*Q where P are row pivots and Q are column pivots.
+ * The permuted matrix is P*A*Q, where P is the row permutation and Q is the column permutation provided
+ * by the {@link ComputePermutation ordering}. If the ordering does not provide one of the two permutations
+ * it is treated as identity. In symmetric mode the row permutation is applied to both sides, P*A*P<sup>T</sup>,
+ * and the column permutation is ignored.
  *
  * @author Peter Abeles
  */
@@ -37,7 +41,13 @@ public class ApplyFillReductionPermutation_DSCC {
 
     // storage for permuted A matrix
     DMatrixSparseCSC Aperm = new DMatrixSparseCSC(1, 1, 0);
+    int[] p = new int[0]; // row pivots
     int[] pinv = new int[1]; // inverse row pivots
+    int[] q = new int[0]; // column pivots
+
+    // storage for identity permutations when the ordering doesn't provide one
+    private int[] identRow = new int[0];
+    private int[] identCol = new int[0];
 
     IGrowArray gw = new IGrowArray();
 
@@ -62,31 +72,119 @@ public class ApplyFillReductionPermutation_DSCC {
         fillReduce.process(A);
 
         IGrowArray gp = fillReduce.getRow();
-        if (gp == null)
-            throw new RuntimeException("No row permutation matrix");
+        IGrowArray gq = fillReduce.getColumn();
 
-        if (pinv.length < gp.length)
-            pinv = new int[gp.length];
-        CommonOps_DSCC.permutationInverse(gp.data, pinv, gp.length);
-        if (symmetric)
+        p = gp != null ? gp.data : identity(true, A.numRows);
+        if (pinv.length < A.numRows)
+            pinv = new int[A.numRows];
+        CommonOps_DSCC.permutationInverse(p, pinv, A.numRows);
+
+        if (symmetric) {
+            // rows and columns are permuted by the same permutation
+            q = p;
             CommonOps_DSCC.permuteSymmetric(A, pinv, Aperm, gw);
-        else
-            CommonOps_DSCC.permuteRowInv(pinv, A, Aperm);
+        } else {
+            q = gq != null ? gq.data : identity(false, A.numCols);
+            CommonOps_DSCC.permute(pinv, A, q, Aperm);
+        }
         return Aperm;
     }
 
+    private int[] identity( boolean row, int length ) {
+        int[] storage = row ? identRow : identCol;
+        if (storage.length < length) {
+            storage = new int[length];
+            for (int i = 0; i < length; i++) {
+                storage[i] = i;
+            }
+            if (row)
+                identRow = storage;
+            else
+                identCol = storage;
+        }
+        return storage;
+    }
+
+    /**
+     * Inverse of the row permutation. Only valid after {@link #apply} has been called. null if no fill reduction.
+     */
     public @Nullable int[] getArrayPinv() {
         return fillReduce == null ? null : pinv;
     }
 
-    @SuppressWarnings("NullAway")
+    /**
+     * Row permutation. Only valid after {@link #apply} has been called. null if no fill reduction.
+     */
     public @Nullable int[] getArrayP() {
-        return fillReduce == null ? null : fillReduce.getRow().data;
+        return fillReduce == null ? null : p;
     }
 
-    @SuppressWarnings("NullAway")
+    /**
+     * Column permutation. Only valid after {@link #apply} has been called. null if no fill reduction.
+     */
     public @Nullable int[] getArrayQ() {
-        return fillReduce == null ? null : fillReduce.getColumn().data;
+        return fillReduce == null ? null : q;
+    }
+
+    /**
+     * <p>Returns the inverse row permutation to apply to a right hand side before the triangular solves, formed by
+     * composing this fill reduction's row permutation with the decomposition's own (numeric or structural) row
+     * pivots. The result is used the same way in every solver:</p>
+     *
+     * <ul>
+     *     <li>dense: {@code CommonOps_DSCC.permuteInv(rowPinv, b, x, n)}</li>
+     *     <li>sparse: {@code CommonOps_DSCC.permute(rowPinv, B, null, Bp)}</li>
+     * </ul>
+     *
+     * <p>This is the single location where the direction and composition of the row permutation is decided, so no
+     * solver has to reason about it. For decompositions with no numeric row pivots (e.g. Cholesky) use
+     * {@link #fillRowPermInv()} instead.</p>
+     *
+     * @param numericRowPinv (Input) The decomposition's inverse row pivots.
+     * @param work (Optional) Storage for the composed permutation. Only used when a composition is required.
+     * @return The inverse row permutation, or {@code numericRowPinv} unchanged if there is no fill reduction.
+     */
+    public int[] rowPermInv( int[] numericRowPinv, @Nullable IGrowArray work ) {
+        if (fillReduce == null)
+            return numericRowPinv;
+        // pinv is grow-only, so its length is only an upper bound; the current matrix's row count is Aperm.numRows
+        int n = Aperm.numRows;
+        int[] combined = UtilEjml.adjust(work, n);
+        for (int i = 0; i < n; i++) {
+            combined[i] = numericRowPinv[pinv[i]];
+        }
+        return combined;
+    }
+
+    /**
+     * Variant of {@link #rowPermInv(int[], IGrowArray)} for decompositions with no numeric row pivots to compose
+     * with, e.g. Cholesky. Returns just the fill reduction's inverse row permutation, or null if there is none.
+     */
+    public @Nullable int[] fillRowPermInv() {
+        return fillReduce == null ? null : pinv;
+    }
+
+    /**
+     * Undoes the fill reduction column permutation on a dense solution. {@code out[q[i]] = t[i]}. If there is no
+     * fill reduction 't' is copied into 'out' unchanged. Callers that manage their own buffers should guard this
+     * with {@link #isApplied()} to avoid the copy.
+     */
+    public void undoColumnPermutation( double[] t, double[] out, int n ) {
+        if (fillReduce == null)
+            System.arraycopy(t, 0, out, 0, n);
+        else
+            CommonOps_DSCC.permuteInv(q, t, out, n);
+    }
+
+    /**
+     * Undoes the fill reduction column permutation on a sparse solution. Row {@code i} of 't' becomes row
+     * {@code q[i]} of 'out'. If there is no fill reduction 't' is copied into 'out' unchanged.
+     */
+    public void undoColumnPermutation( DMatrixSparseCSC t, DMatrixSparseCSC out ) {
+        if (fillReduce == null)
+            out.setTo(t);
+        else
+            CommonOps_DSCC.permuteRowInv(q, t, out);
     }
 
     public IGrowArray getGw() {

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/decomposition/lu/GenericLuTests_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/decomposition/lu/GenericLuTests_DSCC.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public abstract class GenericLuTests_DSCC extends GenericDecompositionTests_DSCC {
 
     private FillReducing permTests[] =
-            new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY};
+            new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY, FillReducing.RANDOM};
 
     public abstract LUSparseDecomposition_F64<DMatrixSparseCSC> create( FillReducing permutation );
 
@@ -109,7 +109,25 @@ public abstract class GenericLuTests_DSCC extends GenericDecompositionTests_DSCC
         DMatrixSparseCSC found = new DMatrixSparseCSC(PL.numCols, U.numCols, 0);
         CommonOps_DSCC.mult(PL, U, found);
 
-        EjmlUnitTests.assertEquals(Acpy, found, UtilEjml.TEST_F64);
+        // P'*L*U reconstructs the fill reduced matrix Pfr*A*Qfr, not A itself
+        EjmlUnitTests.assertEquals(applyFillReduction(lu, Acpy), found, UtilEjml.TEST_F64);
+    }
+
+    /** Applies the decomposition's fill reduction permutation to A. Returns A if there is none. */
+    private DMatrixSparseCSC applyFillReduction( LUSparseDecomposition_F64<DMatrixSparseCSC> lu,
+                                                 DMatrixSparseCSC A ) {
+        if (!(lu instanceof LuUpLooking_DSCC))
+            return A;
+        LuUpLooking_DSCC alg = (LuUpLooking_DSCC)lu;
+        if (!alg.isReduceFill())
+            return A;
+
+        int[] pinv = alg.getApplyFillReduction().getArrayPinv();
+        int[] q = alg.getApplyFillReduction().getArrayQ();
+        DMatrixSparseCSC Aperm = new DMatrixSparseCSC(A.numRows, A.numCols, A.nz_length);
+        CommonOps_DSCC.permute(pinv, A, q, Aperm);
+        Aperm.sortIndices(null);
+        return Aperm;
     }
 
     @Test

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/decomposition/qr/TestQrLeftLookingDecomposition_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/decomposition/qr/TestQrLeftLookingDecomposition_DSCC.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestQrLeftLookingDecomposition_DSCC extends GenericDecompositionTests_DSCC {
 
     protected FillReducing[] permutationTests =
-            new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY};
+            new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY, FillReducing.RANDOM};
 
     @Override
     public DMatrixSparseCSC createMatrix(int N) {
@@ -106,9 +106,14 @@ public class TestQrLeftLookingDecomposition_DSCC extends GenericDecompositionTes
         ComputePermutation<DMatrixSparseCSC> reducePerm = FillReductionFactory_DSCC.create(reduce);
         QrLeftLookingDecomposition_DSCC alg = new QrLeftLookingDecomposition_DSCC(reducePerm);
 
-        if (alwaysHasSolution)
-            assertTrue(alg.decompose(A));
-        else if (!alg.decompose(A))
+        if (alwaysHasSolution) {
+            if (!alg.decompose(A)) {
+                // For wide matrices a fill reduction permutation can produce a structure which requires
+                // column pivoting, in which case the decomposition legitimately reports that it can't proceed
+                assertTrue(numRows < numCols && reduce == FillReducing.RANDOM);
+                return;
+            }
+        } else if (!alg.decompose(A))
             return;
 
         if (!alg.inputModified()) {
@@ -122,7 +127,16 @@ public class TestQrLeftLookingDecomposition_DSCC extends GenericDecompositionTes
         DMatrixSparseCSC found = new DMatrixSparseCSC(Q.numRows, R.numCols, 0);
         CommonOps_DSCC.mult(Q, R, found, null, null);
 
-        EjmlUnitTests.assertEquals(A_cpy, found, UtilEjml.TEST_F64);
+        // Q*R reconstructs the fill reduced matrix Pfr*A*Qfr, not A itself
+        DMatrixSparseCSC expected = A_cpy;
+        if (alg.isFillPermutated()) {
+            expected = new DMatrixSparseCSC(A_cpy.numRows, A_cpy.numCols, A_cpy.nz_length);
+            CommonOps_DSCC.permute(alg.getApplyFillReduction().getArrayPinv(), A_cpy,
+                    alg.getApplyFillReduction().getArrayQ(), expected);
+            expected.sortIndices(null);
+        }
+
+        EjmlUnitTests.assertEquals(expected, found, UtilEjml.TEST_F64);
     }
 
     /**

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/linsol/GenericLinearSolverSparseTests_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/linsol/GenericLinearSolverSparseTests_DSCC.java
@@ -39,7 +39,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 // TODO Add a test that makes sure identify permutation produces identical results to no permutation
 public abstract class GenericLinearSolverSparseTests_DSCC extends EjmlStandardJUnit {
-    protected FillReducing[] permutationTests = new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY};
+    protected FillReducing[] permutationTests = new FillReducing[]{
+            FillReducing.NONE, FillReducing.IDENTITY, FillReducing.RANDOM};
 
     // used to adjust tolerance threshold
     protected double equalityTolerance = UtilEjml.TEST_F64;

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/linsol/chol/TestLinearSolverCholesky_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/linsol/chol/TestLinearSolverCholesky_DSCC.java
@@ -40,7 +40,9 @@ public class TestLinearSolverCholesky_DSCC extends GenericLinearSolverSparseTest
         canHandleTall = false;
         canDecomposeZeros = false;
 
-        permutationTests = new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY}; // todo add a cholesky specific
+        // Cholesky uses the symmetric mode, which only sees the ordering's row permutation.
+        // RANDOM applies a nontrivial P*A*P' which keeps the matrix SPD.
+        permutationTests = new FillReducing[]{FillReducing.NONE, FillReducing.IDENTITY, FillReducing.RANDOM};
     }
 
     @Override

--- a/main/ejml-dsparse/test/org/ejml/sparse/csc/linsol/lu/TestLinearSolverLu_DSCC.java
+++ b/main/ejml-dsparse/test/org/ejml/sparse/csc/linsol/lu/TestLinearSolverLu_DSCC.java
@@ -57,6 +57,48 @@ public class TestLinearSolverLu_DSCC extends GenericLinearSolverSparseTests_DSCC
         return RandomMatrices_DSCC.symmetricPosDef(size, 0.25, rand);
     }
 
+    /**
+     * Solve with a nontrivial fill reduction permutation. Regression test for
+     * <a href="https://github.com/lessthanoptimal/ejml/issues/207">issue 207</a>. The permutations contain
+     * 3-cycles (are not involutions), which catches a missing permutation of the right hand side as well as an
+     * un-permutation of the solution applied in the wrong direction. Identity permutations catch neither.
+     */
+    @Test
+    public void nontrivialFillReducePermutation() {
+        int[] p = {1, 2, 0, 4, 5, 3};
+        int[] q = {2, 0, 1, 5, 3, 4};
+
+        ComputePermutation<DMatrixSparseCSC> perm = new ComputePermutation<>(true, true) {
+            @Override public void process( DMatrixSparseCSC m ) {
+                prow.reshape(p.length);
+                System.arraycopy(p, 0, prow.data, 0, p.length);
+                pcol.reshape(q.length);
+                System.arraycopy(q, 0, pcol.data, 0, q.length);
+            }
+        };
+
+        DMatrixSparseCSC A = RandomMatrices_DSCC.symmetricPosDef(p.length, 0.4, rand);
+
+        LinearSolverSparse<DMatrixSparseCSC, DMatrixRMaj> solver =
+                new LinearSolverLu_DSCC(new LuUpLooking_DSCC(perm));
+
+        DMatrixRMaj X = create(A.numCols, 3);
+        DMatrixRMaj B = new DMatrixRMaj(A.numRows, 3);
+        CommonOps_DSCC.mult(A, X, B);
+
+        assertTrue(solver.setA(A));
+        DMatrixRMaj foundX = create(A.numCols, 3);
+        solver.solve(B, foundX);
+        EjmlUnitTests.assertRelativeEquals(X, foundX, equalityTolerance);
+
+        DMatrixSparseCSC Xs = createSparse(A.numCols, 3);
+        DMatrixSparseCSC Bs = new DMatrixSparseCSC(1, 1, 1);
+        CommonOps_DSCC.mult(A, Xs, Bs);
+        DMatrixSparseCSC foundXs = new DMatrixSparseCSC(1, 1, 1);
+        solver.solveSparse(Bs, foundXs);
+        EjmlUnitTests.assertEquals(Xs, foundXs, equalityTolerance);
+    }
+
     @Test
     public void testCase0() {
         DMatrixSparseCSC A = DConvertMatrixStruct.convert(A0_dense, (DMatrixSparseCSC)null, 0);


### PR DESCRIPTION
Solves #207.

## Problem

Sparse fill-reduction orderings were broken for any non-identity permutation.

LU and Cholesky could return plausible but incorrect results. Sparse QR could crash. This went unnoticed because the only orderings covered by tests were `NONE` and `IDENTITY`. `FillReducing.RANDOM` existed but was not used in the test suite.

There were six issues across LU and QR:

1. **`ApplyFillReductionPermutation_DSCC`**
   - Its documentation says it applies `P*A*Q`.
   - It only applied the row permutation `P`.
   - It ignored the column permutation `Q`.
   - It also required a row permutation and threw `"No row permutation matrix"` otherwise.

2. **`LuUpLooking_DSCC.performLU()`**
   - Used the row permutation array (`getArrayP()`) as the column ordering during factorization.

3. **`LinearSolverLu_DSCC.solve()`**
   - Did not apply the fill-reduction row permutation to `b`.
   - Restored `x` in the wrong direction: it used `permute` instead of `permuteInv`.

4. **`LinearSolverLu_DSCC.solveSparse()`**
   - Did not apply fill reduction at all.

5. **`QrLeftLookingDecomposition_DSCC.decompose()`**
   - Crashed with `ArrayIndexOutOfBoundsException` for nontrivial column permutations.
   - The symbolic QR phase analyzed columns in natural order, while the numeric phase processed permuted columns.

6. **`LinearSolverQrLeftLooking_DSCC.solve()` and `solveSparse()`**
   - Restored `x` using the row permutation in the forward direction.
   - They should use the column permutation in the inverse direction.

While fixing these, there was one more issue:

7. **`LinearSolverCholesky_DSCC.solveSparse()`**
   - Passed the fill inverse permutation as `pinv` to `TriangularSolver_DSCC.solve()`.
   - That argument maps solution indices to factor columns; it is not a right-hand-side row permutation.
   - Sparse Cholesky solves were therefore also wrong under nontrivial orderings. The dense path was already correct.

## Cause

Each solver handled fill-reduction permutations differently:

- Cholesky used a symmetric `pinv` approach.
- LU applied the row permutation to both sides.
- QR mixed physical row permutation with logical column ordering.

`ApplyFillReductionPermutation_DSCC` was intended to provide a common implementation, but it only handled matrix permutation. Each solver separately handled `b` and `x`, which led to inconsistent conventions and direction mistakes.

## Fix

The common convention is now:

```text
P * A * Q
```

The decomposition operates on `P*A*Q`, where `P` and `Q` come from the fill-reduction ordering. For symmetric orderings such as SYMRCM or AMD, `Q = Pᵀ`.

### `ApplyFillReductionPermutation_DSCC`

It now applies both row and column permutations.

- Missing row or column permutations are treated as identity.
- This allows column-only orderings such as COLAMD.
- Symmetric mode exposes matching row/column permutations through the same interface.

Permutation handling is now centralized in this class:

- `rowPermInv(numericRowPinv, work)`
  - Combines fill-reduction row permutations with LU numeric pivots or QR structural pivots.
  - Used for both dense and sparse RHS paths.

- `undoColumnPermutation(double[] ...)`
- `undoColumnPermutation(DMatrixSparseCSC ...)`
  - Restore the solution using the fill-reduction column permutation.

All LU, QR, and Cholesky solve paths now follow the same pattern:

```text
rowPinv = reduce.rowPermInv(decompositionPivots, work)
apply rowPinv to b
run the solver's triangular solves
undo the column permutation on x
```

The solver-specific parts are now limited to the decomposition pivot array and the triangular solve implementation.

### LU

- `LuUpLooking_DSCC` now processes column `k` directly, since the input matrix has already been fully permuted.
- This removes the row-permutation-used-as-column-ordering bug.
- `computeDeterminant()` now includes the sign of both fill permutations.
- Updated the old CSparse pivoting comment to refer to the correct index.

### QR

- QR no longer has separate symbolic and numeric column orders.
- Since the matrix is physically permuted before both phases, they see the same structure.
- This fixes the nontrivial-permutation crash.

### API

LU and QR now expose `getApplyFillReduction()`, matching the existing Cholesky setup.

## Tests

Added `FillReducing.RANDOM` to the permutation test cases for LU, QR, and Cholesky.

Also added or updated tests for:

- LU and QR factor reconstruction against `Pfr * A * Qfr`, rather than directly against `A`.
- A deterministic LU regression using two 3-cycle permutations. These are intentionally not self-inverse, so direction mistakes cannot accidentally cancel out.
- Sparse and dense RHS paths.
- QR wide-matrix behavior under `RANDOM`.

For wide matrices, QR may now return `false` under a fill-reduction ordering if the resulting structure requires column pivoting. Previously this case crashed.

## Verification
- Full `org.ejml.sparse` dsparse suite: **358/358 passing**

## Compatibility

There are no public signature changes for the solve APIs.

- `NONE` is unchanged; the fill-reduction object is null and all new logic is skipped.
- `IDENTITY` gives the same numerical results.
- Behavior changes only for nontrivial fill-reduction permutations, where results were previously wrong or QR crashed.

One consequence is that LU and QR factors now reconstruct the fill-reduced matrix:

```text
Pfr * A * Qfr
```

rather than `A` directly.

Callers reconstructing `A` from LU or QR factors need the fill-reduction permutation as well as the decomposition's numeric pivot data. It is available through `getApplyFillReduction()`.

## Follow-up

This should unblock SYMRCM and similar orderings. A symmetric ordering can return its ordering through both `prow` and `pcol`, and it will now work consistently with Cholesky, LU, and QR.